### PR TITLE
Fix CIGAR clipping length error

### DIFF
--- a/include/RapMapUtils.hpp
+++ b/include/RapMapUtils.hpp
@@ -374,7 +374,7 @@ namespace rapmap {
 		    pos = 0;
 	    } else if (pos + readLen > txpLen) {
 		    int32_t matchLen = txpLen - pos;
-		    int32_t clipLen = pos + readLen - matchLen;
+		    int32_t clipLen = pos + readLen - txpLen;
 		    cigarStr.write("{}M{}S", matchLen, clipLen);
 	    } else {
 		    cigarStr.write("{}M", readLen);


### PR DESCRIPTION
The region clipping to the right of a transcript should be the end position of the mapping minus the end position of the transcript.

Should fix COMBINE-lab/RapMap#9
