### PR TITLE
Fixing problems with no mappings

### DIFF
--- a/src/RapMapMapper.cpp
+++ b/src/RapMapMapper.cpp
@@ -776,8 +776,8 @@ void processReadsSingle(single_parser* parser,
         // Get rid of last newline
         if (!outStr.empty()) {
             outStr.pop_back();
+            outQueue->info() << std::move(outStr);
         }
-	    outQueue->info() << std::move(outStr);
 	    sstream.clear();
 	}
 	/*
@@ -889,8 +889,8 @@ void processReadsPair(paired_parser* parser,
         // Get rid of last newline
         if (!outStr.empty()){
             outStr.pop_back();
+            outQueue->info() << std::move(outStr);
         }
-	    outQueue->info() << std::move(outStr);
 	    sstream.clear();
 	}
 

--- a/src/RapMapMapper.cpp
+++ b/src/RapMapMapper.cpp
@@ -774,7 +774,9 @@ void processReadsSingle(single_parser* parser,
 	if (!noOutput) {
         std::string outStr(sstream.str());
         // Get rid of last newline
-        outStr.pop_back();
+        if (!outStr.empty()) {
+            outStr.pop_back();
+        }
 	    outQueue->info() << std::move(outStr);
 	    sstream.clear();
 	}
@@ -885,7 +887,9 @@ void processReadsPair(paired_parser* parser,
 	if (!noOutput) {
         std::string outStr(sstream.str());
         // Get rid of last newline
-        outStr.pop_back();
+        if (!outStr.empty()){
+            outStr.pop_back();
+        }
 	    outQueue->info() << std::move(outStr);
 	    sstream.clear();
 	}

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -1210,8 +1210,8 @@ void processReadsSingleSA(single_parser * parser,
             // Get rid of last newline
             if (!outStr.empty()) {
                 outStr.pop_back();
+                outQueue->info() << std::move(outStr);
             }
-            outQueue->info() << std::move(outStr);
             sstream.clear();
             /*
              iomutex->lock();
@@ -1314,8 +1314,8 @@ void processReadsPairSA(paired_parser* parser,
             // Get rid of last newline
             if (!outStr.empty()) {
                 outStr.pop_back();
+                outQueue->info() << std::move(outStr);
             }
-            outQueue->info() << std::move(outStr);
             sstream.clear();
 	        /*
             iomutex->lock();

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -1208,7 +1208,9 @@ void processReadsSingleSA(single_parser * parser,
         if (!noOutput) {
             std::string outStr(sstream.str());
             // Get rid of last newline
-            outStr.pop_back();
+            if (!outStr.empty()) {
+                outStr.pop_back();
+            }
             outQueue->info() << std::move(outStr);
             sstream.clear();
             /*
@@ -1310,7 +1312,9 @@ void processReadsPairSA(paired_parser* parser,
         if (!noOutput) {
             std::string outStr(sstream.str());
             // Get rid of last newline
-            outStr.pop_back();
+            if (!outStr.empty()) {
+                outStr.pop_back();
+            }
             outQueue->info() << std::move(outStr);
             sstream.clear();
 	        /*


### PR DESCRIPTION
Whenever a batch of 1,000 reads had 0 mappings, pop_back() caused a segmentation fault, probably because the string is empty.

Additionally, when this happens a new empty line was output for each group of empty reads, causing samtools to fail.

(By the way, having no read among 1,000 to map anywhere is a very rare event.)