### PR TITLE
Output final hitrate (useful for QC)

### DIFF
--- a/src/RapMapMapper.cpp
+++ b/src/RapMapMapper.cpp
@@ -1129,7 +1129,9 @@ int rapMapMap(int argc, char* argv[]) {
 		}
 		for (auto& t : threads) { t.join(); }
 	    }
-	    consoleLog->info("done mapping reads.");
+	    consoleLog->info("Done mapping reads.");
+        consoleLog->info("In total saw {} reads.", hctrs.numReads);
+        consoleLog->info("Final # hits per read = {}", hctrs.totHits / static_cast<float>(hctrs.numReads));
 	    consoleLog->info("Discarded {} reads because they had > {} alignments",
 		    hctrs.tooManyHits, maxNumHits.getValue());
 

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -481,7 +481,11 @@ int rapMapSAMap(int argc, char* argv[]) {
             for (auto& t : threads) { t.join(); }
         }
 	std::cerr << "\n\n";
-    consoleLog->info("done mapping reads.");
+    
+        
+    consoleLog->info("Done mapping reads.");
+    consoleLog->info("In total saw {} reads.", hctrs.numReads);
+    consoleLog->info("Final # hits per read = {}", hctrs.totHits / static_cast<float>(hctrs.numReads));
 	consoleLog->info("flushing output queue.");
 	outLog->flush();
 	/*


### PR DESCRIPTION
I propose outputting the final hit rate in the log. I think it is an interesting value to look at for QC purposes. In particular I'm investigating the relation to sequenced read length.