### PR TITLE
Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,15 @@ enable_testing()
 
 project (RapMap)
 
-set(CPACK_PACKAGE_VERSION "0.3.0")
+set(CPACK_PACKAGE_VERSION "0.4.0")
 SET(CPACK_PACKAGE_VERSION_MAJOR "0")
-set(CPACK_PACKAGE_VERSION_MINOR "3")
+set(CPACK_PACKAGE_VERSION_MINOR "4")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 set(PROJECT_VERSION ${CPACK_PACKAGE_VERSION})
 set(CPACK_GENERATOR "TGZ")
 set(CPACK_SOURCE_GENERATOR "TGZ")
 set(CPACK_PACKAGE_VENDOR "Stony Brook University")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "RapMap - Wicked-fast quasi/pseudo/lightweight alignment")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "RapMap - Wicked-fast qasi-mapping")
 set(CPACK_PACKAGE_NAME
   "${CMAKE_PROJECT_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME
@@ -26,8 +26,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 #    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -DEMPHF_USE_POPCOUNT")
 #endif(SSE4_2_FOUND)
 
-set (WARNING_IGNORE_FLAGS "-Wno-deprecated-register -Wno-c++11-narrowing -Wno-unknown-pragmas")
-set (BOOST_CXX_FLAGS "-Wno-deprecated-register -std=c++11")
+if (APPLE)
+set (WARNING_IGNORE_FLAGS "-Wno-deprecated-register -Wno-unknon-pragmas -Wreturn-type -Werror=return-type")
+else()
+set (WARNING_IGNORE_FLAGS "-Wno-unknown-pragmas -Wreturn-type -Werror=return-type")
+endif()
+
 ## Prefer static to dynamic libraries
 SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
@@ -38,7 +42,14 @@ else()
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -funroll-loops -fPIC -fomit-frame-pointer -O4 -DHAVE_ANSI_TERM -Wall -std=c++11 -Wno-unknown-pragmas -Wreturn-type -Werror=return-type")
+
+if (QUIET_BUILD)
+  set(WALL "")
+else()
+  set(WALL "-Wall")
+endif()
+
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -funroll-loops -fPIC -fomit-frame-pointer -O4 -DHAVE_ANSI_TERM ${WALL} -std=c++11")
 
 ##
 # OSX is strange (some might say, stupid in this regard).  Deal with it's quirkines here.
@@ -98,10 +109,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
     endif()
 
     set (WARNING_IGNORE_FLAGS "${WARNING_IGNORE_FLAGS} -Wno-unused-local-typedefs")
-    set (BOOST_TOOLSET "gcc")
-    set (BOOST_CONFIGURE_TOOLSET "--with-toolset=gcc")
-	set (BCXX_FLAGS "-std=c++11")
-    set (BOOST_EXTRA_FLAGS toolset=gcc cxxflags=${BCXX_FLAGS})
 # Tentatively, we support clang now
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     set(CLANG TRUE)
@@ -111,10 +118,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     if (HAVE_LIBCPP)
         message ("It appears that you're compiling with clang and that libc++ is available, so I'll use that")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-	    set (BOOST_TOOLSET "clang")
-        set (BOOST_CONFIGURE_TOOLSET "--with-toolset=clang")
-	    set (BCXX_FLAGS "-stdlib=libc++ -DBOOST_HAS_INT128")
-	    set (BOOST_EXTRA_FLAGS toolset=clang cxxflags=${BCXX_FLAGS} linkflags="-stdlib=libc++")
         set (JELLYFISH_CXX_FLAGS "-stdlib=libc++")
     # Otherwise, use libstdc++ (and make it static)
     else()

--- a/README.md
+++ b/README.md
@@ -89,3 +89,25 @@ RapMap is experimental, and the code, at this point, is subject to me testing ou
 # License 
 
 Since RapMap uses Jellyfish, it must be released under the GPL.  However, this is currently the only GPL dependency.  If it can be replaced, I'd like to re-license RapMap under the BSD license.  I'd be happy to accept pull-requests that replace the Jellyfish components with a library released under a more liberal license (BSD-compatible), but note that I will *not* accept such pull requests if they reduce the speed or increase the memory consumption over the Jellyfish-based version.
+
+# Citation
+
+If you use RapMap, or wish to cite the quasi-mapping concept or our algorithm for computing quasi-mappings, please 
+use this bibtex entry. 
+
+```
+@article{Srivastava15062016,
+author = {Srivastava, Avi and Sarkar, Hirak and Gupta, Nitish and Patro, Rob}, 
+title = {RapMap: a rapid, sensitive and accurate tool for mapping RNA-seq reads to transcriptomes},
+volume = {32}, 
+number = {12}, 
+pages = {i192-i200}, 
+year = {2016}, 
+doi = {10.1093/bioinformatics/btw277},
+URL = {http://bioinformatics.oxfordjournals.org/content/32/12/i192.abstract}, 
+eprint = {http://bioinformatics.oxfordjournals.org/content/32/12/i192.full.pdf+html}, 
+journal = {Bioinformatics} 
+}
+```
+
+Other citation formats for the RapMap paper are available [here](http://bioinformatics.oxfordjournals.org/citmgr?gca=bioinfo%3B32%2F12%2Fi192).

--- a/include/BooPHF.hpp
+++ b/include/BooPHF.hpp
@@ -533,11 +533,11 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		//for debug purposes
 		void print() const
 		{
-			printf("bit array of size %lli: \n",_size);
+			printf("bit array of size %lu: \n",_size);
 			for(uint64_t ii = 0; ii< _size; ii++)
 			{
 				if(ii%10==0)
-					printf(" (%llu) ",ii);
+					printf(" (%lu) ",ii);
 				int val = (_bitArray[ii >> 6] >> (ii & 63 ) ) & 1;
 				printf("%i",val);
 			}
@@ -546,7 +546,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			printf("rank array : size %lu \n",_ranks.size());
 			for (uint64_t ii = 0; ii< _ranks.size(); ii++)
 			{
-				printf("%llu :  %lli,  ",ii,_ranks[ii]);
+				printf("%lu :  %lu,  ",ii,_ranks[ii]);
 			}
 			printf("\n");
 		}

--- a/include/FrugalBooMap.hpp
+++ b/include/FrugalBooMap.hpp
@@ -1,0 +1,294 @@
+#ifndef __BOO_MAP_FRUGAL__
+#define __BOO_MAP_FRUGAL__
+
+#include "BooPHF.hpp"
+#include "RapMapUtils.hpp"
+
+#include "cereal/types/vector.hpp"
+#include "cereal/types/utility.hpp"
+#include "cereal/archives/binary.hpp"
+
+#include <fstream>
+#include <vector>
+#include <iterator>
+#include <type_traits>
+
+#include <sys/stat.h>
+
+// adapted from :
+// http://stackoverflow.com/questions/34875315/implementation-my-own-list-and-iterator-stl-c
+template <typename Iter, typename IndexT>
+class KeyProxyIterator {
+public:
+    typedef KeyProxyIterator<Iter, IndexT> self_type;
+    typedef uint64_t value_type;//std::iterator_traits<Iter>::value_type::first_type value_type;
+    typedef value_type& reference;
+    typedef value_type* pointer;
+    typedef std::forward_iterator_tag iterator_category;
+    typedef int64_t difference_type;
+
+    KeyProxyIterator(Iter first, std::vector<IndexT>* saPtr, const char* txtPtr, unsigned int k) : 
+        curr_(first), saPtr_(saPtr), txtPtr_(txtPtr) {}
+    KeyProxyIterator operator++() { KeyProxyIterator i = *this; curr_++; return i; }
+    KeyProxyIterator operator++(int) { ++curr_; return *this; }
+    reference operator*() { 
+        // Does not validate the argument!
+        mer_.from_chars(txtPtr_ + (*saPtr_)[curr_->begin()]);
+        intRep_ = mer_.get_bits(0, 2*k_);
+        return intRep_; 
+    }
+    /*
+    pointer operator->() { 
+        return &(curr_->first); 
+    }
+    */
+    bool operator==(const self_type& rhs) { return curr_ == rhs.curr_; }
+    bool operator!=(const self_type& rhs) { return curr_ != rhs.curr_; }
+    bool operator<(const self_type& rhs) { return curr_ < rhs.curr_; }
+    bool operator<=(const self_type& rhs) { return curr_ <= rhs.curr_; }
+    
+private:
+    rapmap::utils::my_mer mer_;
+    uint64_t intRep_;
+    Iter curr_;
+    unsigned int k_;
+    std::vector<IndexT>* saPtr_{nullptr};
+    const char* txtPtr_{nullptr};
+};
+
+template <typename IterT>
+class KVProxy {
+public:
+    typedef KVProxy<IterT> self_type;
+    typedef typename std::iterator_traits<IterT>::value_type ValueT;
+    typedef std::pair<uint64_t, ValueT> value_type;
+    typedef value_type& reference;
+    typedef value_type* pointer;
+
+    KVProxy(uint64_t mer, IterT it, bool isEnd = false) : curr_(it) {
+        if(!isEnd) {pair_ = std::make_pair(mer, *it);}
+    }
+    reference operator*() { return pair_; }
+    pointer operator->() { return &pair_; }
+    bool operator==(const self_type& rhs) { return curr_ == rhs.curr_; }
+    bool operator!=(const self_type& rhs) { return curr_ != rhs.curr_; }
+    bool operator<(const self_type& rhs) { return curr_ < rhs.curr_; }
+    bool operator<=(const self_type& rhs) { return curr_ <= rhs.curr_; }
+private:
+    IterT curr_;
+    std::pair<uint64_t, ValueT> pair_;
+};
+
+
+// Unlike the standard "generic" BooMap, the frugal variant
+// *does not* store the key.  Rather, it assumes we have a
+// pointer to the suffix array, and it "spot checks" the index 
+// returned by the perfect hash by ensuring that the suffix at
+// the corresponding offset starts with the query k-mer.
+template <typename KeyT, typename ValueT>
+class FrugalBooMap {
+public:
+    using HasherT = boomphf::SingleHashFunctor<KeyT>;
+    using BooPHFT = boomphf::mphf<KeyT, HasherT>;
+    typedef typename ValueT::index_type IndexT;
+    using IteratorT = KVProxy<typename std::vector<ValueT>::iterator>;
+
+    //using IteratorT = typename std::vector<std::pair<KeyT, ValueT>>::iterator;
+
+    FrugalBooMap() : built_(false) {}
+    void setSAPtr(std::vector<IndexT>* saPtr) { saPtr_ = saPtr; }
+    void setTextPtr(const char* txtPtr, size_t textLen) { txtPtr_ = txtPtr; textLen_ = textLen; }
+
+    void add(KeyT&& k, ValueT&& v) {
+        // In the frugal map, we don't even keep the key!
+        data_.emplace_back(v);
+    }
+
+
+    bool validate_hash(){
+        auto k_ = rapmap::utils::my_mer::k();
+        rapmap::utils::my_mer mer_;
+        for( auto& e : data_ ) {
+            auto mer = getKmerFromInterval_(e);
+            if (mer != getKmerFromInterval_(data_[boophf_->lookup(mer)]) ) {
+                std::cerr << "lookup of " << mer << " failed!\n";
+            }
+        }
+        return true;
+    }
+
+
+    bool build(int nthreads=1) {
+        size_t numElem = data_.size();
+        k_ = rapmap::utils::my_mer::k();
+        twok_ = 2 * k_; 
+        KeyProxyIterator<decltype(data_.begin()), IndexT> kb(data_.begin(), saPtr_, txtPtr_, k_);
+        KeyProxyIterator<decltype(data_.begin()), IndexT> ke(data_.end(), saPtr_, txtPtr_, k_);
+        auto keyIt = boomphf::range(kb, ke);
+        BooPHFT* ph = new BooPHFT(numElem, keyIt, nthreads);
+        boophf_.reset(ph);
+        std::cerr << "reordering keys and values to coincide with phf ... ";
+        /*
+        std::vector<size_t> inds; inds.reserve(data_.size());
+        for (size_t i = 0; i < data_.size(); ++i) {
+            inds.push_back(ph->lookup(data_[i].first));
+        }
+        reorder_destructive_(inds.begin(), inds.end(), data_.begin());
+        */
+        reorder_fn_();
+        validate_hash();
+        std::cerr << "done\n";
+        built_ = true;
+        return built_;
+    }
+
+    inline IteratorT find(const KeyT& k) {
+        auto intervalIndex = boophf_->lookup(k);
+        auto ind = data_[intervalIndex].begin();
+
+        if (ind < saPtr_->size()) {
+            auto textInd = (*saPtr_)[ind];
+            if (textInd + k < textLen_) {
+                rapmap::utils::my_mer m(txtPtr_ + textInd);
+                // If what we find matches the key, return the iterator
+                // otherwise we don't have the key (it must have been here if it
+                // existed).
+                return (m == k) ? IteratorT(m, data_.begin() + intervalIndex) : end();
+            } 
+        } 
+        // The search sould have been invalid, the key must not exist.
+        return end();
+    }
+    
+    /**
+     * NOTE: This function *assumes* that the key is in the hash.
+     * If it isn't, you'll get back a random element!
+     */
+    /*
+    inline ValueT& operator[](const KeyT& k) {
+        auto ind = boophf_->lookup(k);
+        return (ind < data_.size() ? data_[ind].second : data_[0].second);
+    }
+    */
+    
+    inline IteratorT begin() { return IteratorT(0, data_.begin()); }
+    inline IteratorT end() { return IteratorT(0, data_.end(), true); }
+    inline IteratorT cend() const { return IteratorT(0, data_.cend(), true); }
+    inline IteratorT cbegin() const { return IteratorT(0, data_.cbegin()); }
+    
+    void save(const std::string& ofileBase) {
+        if (built_) {
+            std::string hashFN = ofileBase + ".bph";
+            // save the perfect hash function
+            {
+                std::ofstream os(hashFN, std::ios::binary);
+                if (!os.is_open()) {
+                    std::cerr << "BooM: unable to open output file [" << hashFN << "]; exiting!\n";
+                    std::exit(1);
+                }
+                boophf_->save(os);
+                os.close();
+            }
+            // and the values
+            std::string dataFN = ofileBase + ".val";
+            {
+                std::ofstream valStream(dataFN, std::ios::binary);
+                if (!valStream.is_open()) {
+                    std::cerr << "BooM: unable to open output file [" << dataFN << "]; exiting!\n";
+                    std::exit(1);
+                }
+                {
+                    cereal::BinaryOutputArchive outArchive(valStream);
+                    outArchive(data_);
+                }
+                valStream.close();
+            }
+        }
+    }
+    
+    void load(const std::string& ofileBase) {
+        std::string hashFN = ofileBase + ".bph";
+        std::string dataFN = ofileBase + ".val";
+
+        if ( !FileExists_(hashFN.c_str()) ) {
+            std::cerr << "BooM: Looking for perfect hash function file [" << hashFN << "], which doesn't exist! exiting.\n";
+            std::exit(1);
+        }
+        if ( !FileExists_(dataFN.c_str()) ) {
+            std::cerr << "BooM: Looking for key-value file [" << dataFN << "], which doesn't exist! exiting.\n";
+            std::exit(1);
+        }
+
+        // load the perfect hash function
+        {
+            boophf_.reset(new BooPHFT);
+            std::ifstream is(hashFN, std::ios::binary);
+            boophf_->load(is);
+            is.close();
+        }
+        // and the values
+        {
+            std::ifstream dataStream(dataFN, std::ios::binary);
+            {
+                cereal::BinaryInputArchive inArchive(dataStream);
+                inArchive(data_);
+            }
+            dataStream.close();
+        }
+
+        k_ = rapmap::utils::my_mer::k();
+        twok_ = 2*k_;
+        built_ = true;
+    }
+
+private:
+    // Taken from http://stackoverflow.com/questions/12774207/fastest-way-to-check-if-a-file-exist-using-standard-c-c11-c
+    bool FileExists_(const char *path) {
+        struct stat fileStat;
+        if ( stat(path, &fileStat) ) {
+            return false;
+        }
+        if ( !S_ISREG(fileStat.st_mode) ) {
+            return false;
+        }
+        return true;
+    }
+
+    inline KeyT getKmerFromInterval_(ValueT& ival) {
+        auto m = mer_; // copy the global mer to get k-mer object
+        mer_.from_chars(txtPtr_ + (*saPtr_)[ival.begin()]);
+        return mer_.get_bits(0, twok_);
+    }
+
+    void reorder_fn_()  {
+        /* Adapted from code at: http://blog.merovius.de/2014/08/12/applying-permutation-in-constant.html */
+        // Note, we can actually do this with out the bitvector by using the high-order bit 
+        // of the start of the suffix array intervals (since they are signed integers and negative
+        // positions are forbidden). 
+        std::vector<bool> bits(data_.size(), false);
+        for ( size_t i = 0; i < data_.size(); ++i ) {
+            if (!bits[i]) {
+                decltype(data_.front()) v = data_[i];
+                auto j = boophf_->lookup(getKmerFromInterval_(data_[i]));
+                while (i != j) {
+                    auto pj = boophf_->lookup(getKmerFromInterval_(data_[j]));
+                    std::swap(data_[j], v);
+                    bits[j] = 1;
+                    j = pj; 
+                }
+                data_[i] = v;
+            }
+        }
+    }
+
+    rapmap::utils::my_mer mer_;
+    std::vector<IndexT>* saPtr_;
+    const char* txtPtr_; 
+    size_t textLen_;
+    bool built_;
+    std::vector<ValueT> data_;
+    std::unique_ptr<BooPHFT> boophf_{nullptr};
+    unsigned int k_;
+    unsigned int twok_;
+};
+#endif // __BOO_MAP_FRUGAL__

--- a/include/RapMapConfig.hpp
+++ b/include/RapMapConfig.hpp
@@ -26,10 +26,10 @@
 
 namespace rapmap {
     constexpr char majorVersion[] = "0";
-    constexpr char minorVersion[] = "3";
+    constexpr char minorVersion[] = "4";
     constexpr char patchVersion[] = "0";
-    constexpr char version [] = "0.3.0";
-    constexpr uint32_t indexVersion = 2;
+    constexpr char version [] = "0.4.0";
+    constexpr uint32_t indexVersion = 3;
 }
 
 #endif //__RAPMAP_CONFIG_HPP__

--- a/include/RapMapUtils.hpp
+++ b/include/RapMapUtils.hpp
@@ -59,7 +59,12 @@ class RapMapIndex;
 template<typename KeyT, typename ValT, typename HasherT>
 //using RegHashT = google::dense_hash_map<KeyT, ValT, HasherT>;
 using RegHashT = spp::sparse_hash_map<KeyT, ValT, HasherT>;
-//using PerfectHashT = FrugalBooMap<KeyT, ValT>;
+
+template<typename KeyT, typename ValT>
+class FrugalBooMap;
+
+template<typename KeyT, typename ValT>
+using PerfectHashT = FrugalBooMap<KeyT, ValT>;
 
 namespace rapmap {
     namespace utils {

--- a/include/RapMapUtils.hpp
+++ b/include/RapMapUtils.hpp
@@ -168,7 +168,7 @@ namespace rapmap {
 	  end = *(il.begin());
 	}
 	*/
-
+        using index_type = IndexT;
         IndexT begin_;
         IndexT end_;
         

--- a/include/RapMapUtils.hpp
+++ b/include/RapMapUtils.hpp
@@ -689,6 +689,12 @@ namespace rapmap {
                 std::string& readWork,
                 std::string& qualWork);
 
+        void reverseRead(std::string& seq,
+                         std::string& readWork);
+
+
+        std::string reverseComplement(std::string& seq);
+
         template <typename ReadPairT, typename IndexT>
         uint32_t writeAlignmentsToStream(
                 ReadPairT& r,

--- a/include/RapMapUtils.hpp
+++ b/include/RapMapUtils.hpp
@@ -59,6 +59,7 @@ class RapMapIndex;
 template<typename KeyT, typename ValT, typename HasherT>
 //using RegHashT = google::dense_hash_map<KeyT, ValT, HasherT>;
 using RegHashT = spp::sparse_hash_map<KeyT, ValT, HasherT>;
+//using PerfectHashT = FrugalBooMap<KeyT, ValT>;
 
 namespace rapmap {
     namespace utils {
@@ -207,11 +208,15 @@ namespace rapmap {
     class KmerKeyHasher {
         //spp::spp_hash<uint64_t> hasher;
         public:
-        inline size_t operator()(const uint64_t& m) const { //{ return hasher(m); }
+        //inline size_t operator()(const uint64_t& m) const { //{ return hasher(m); }
+        inline size_t operator()(const rapmap::utils::my_mer& m) const { //{ return hasher(m); }
                 //auto k = rapmap::utils::my_mer::k();
                 //auto v = m.get_bits(0, 2*k);
-                auto v = m;
-                return XXH64(static_cast<void*>(&v), 8, 0);
+                //auto v = m;
+            return XXH64(static_cast<void*>(const_cast<rapmap::utils::my_mer::base_type*>(m.data())), sizeof(m.word(0)) * m.nb_words(), 0);
+            }
+        inline size_t operator()(const uint64_t& m) const { //{ return hasher(m); }
+            return XXH64(static_cast<void*>(const_cast<uint64_t*>(&m)), sizeof(m), 0);
             }
     };
 

--- a/include/SACollector.hpp
+++ b/include/SACollector.hpp
@@ -22,629 +22,1369 @@
 #ifndef SA_COLLECTOR_HPP
 #define SA_COLLECTOR_HPP
 
-#include "RapMapUtils.hpp"
 #include "RapMapSAIndex.hpp"
+#include "RapMapUtils.hpp"
 #include "SASearcher.hpp"
 
-#include <iostream>
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 
-template <typename RapMapIndexT>
-class SACollector {
-    public:
-    using OffsetT = typename RapMapIndexT::IndexType;
-    void disableNIP() { disableNIP_ = true; }
-    void enableNIP() { disableNIP_ = false; }
-    void setCoverageRequirement(double req) { covReq_ = req; }
-    void coverageRequirement() { return covReq_; }
+template <typename RapMapIndexT> class SACollector {
+public:
+  using OffsetT = typename RapMapIndexT::IndexType;
 
-    SACollector(RapMapIndexT* rmi) : rmi_(rmi) {}
+  /** Disable NIP skipping **/
+  void disableNIP() { disableNIP_ = true; }
+
+  /** Enable NIP skipping --- default state **/
+  void enableNIP() { disableNIP_ = false; }
+  
+  /** Require a coverage fraction of at least req for all reported mappings **/
+  void setCoverageRequirement(double req) { covReq_ = req; }
+
+  /** Get the current coverage requirement for mappings (0 means no requirement) **/
+  double getCoverageRequirement() const { return covReq_; }
+
+  /** If any hit has a suffix array interval of this length or larger, just skip it **/
+  void setMaxInterval(OffsetT maxInterval) { maxInterval_ = maxInterval; }
+
+  /** Get the maximum allowable suffix array interval **/
+  OffsetT getMaxInterval(OffsetT maxInterval) const { return maxInterval_; }
+  
+    bool getStrictCheck() const { return strictCheck_; };
+    void setStrictCheck(bool sc) { strictCheck_ = sc; }
+    
+  /** Construct an SACollector given an index **/
+  SACollector(RapMapIndexT* rmi) : rmi_(rmi), maxInterval_(1000) {}
+
+    enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
+    // Record if k-mers are hits in the
+    // fwd direction, rc direction or both
+    struct KmerDirScore {
+      KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn,
+                   HitStatus fwdScoreIn, HitStatus rcScoreIn)
+          : kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn),
+            rcScore(rcScoreIn) {}
+      KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
+      bool operator==(const KmerDirScore& other) const {
+        return kpos == other.kpos;
+      }
+      bool operator<(const KmerDirScore& other) const {
+        return kpos < other.kpos;
+      }
+      void print() {
+        std::cerr << "{ " << kmer.to_str() << ", " << kpos << ", "
+                  << ((fwdScore) ? "PRESENT" : "ABSENT") << ", "
+                  << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
+      }
+      rapmap::utils::my_mer kmer;
+      int32_t kpos;
+      HitStatus fwdScore;
+      HitStatus rcScore;
+    };
+
+
+
+
+
     bool operator()(std::string& read,
                     std::vector<rapmap::utils::QuasiAlignment>& hits,
                     SASearcher<RapMapIndexT>& saSearcher,
                     rapmap::utils::MateStatus mateStatus,
-                    bool strictCheck=false,
-                    bool consistentHits=false) {
+                    bool strictCheck = false, bool consistentHits = false) {
+        
+    using QuasiAlignment = rapmap::utils::QuasiAlignment;
+    using MateStatus = rapmap::utils::MateStatus;
 
-        using QuasiAlignment = rapmap::utils::QuasiAlignment;
-        using MateStatus = rapmap::utils::MateStatus;
+    auto& rankDict = rmi_->rankDict;
+    auto& txpStarts = rmi_->txpOffsets;
+    auto& SA = rmi_->SA;
+    auto& khash = rmi_->khash;
+    auto& text = rmi_->seq;
+    auto salen = SA.size();
+    auto hashEnd = khash.end();
+    auto readLen = read.length();
 
-        //auto& posIDs = rmi_->positionIDs;
-        auto& rankDict = rmi_->rankDict;
-        auto& txpStarts = rmi_->txpOffsets;
-        auto& SA = rmi_->SA;
-        auto& khash = rmi_->khash;
-        auto& text = rmi_->seq;
-        uint32_t sampFactor{1};
-        auto salen = SA.size();
-        auto hashEnd = khash.end();
+    auto maxDist = 1.5 * readLen;
+    auto k = rapmap::utils::my_mer::k();
+    auto readStartIt = read.begin();
+    auto readEndIt = read.end();
 
-        auto readLen = read.length();
-        auto maxDist = 1.5 * readLen;
-        auto k = rapmap::utils::my_mer::k();
-        auto readStartIt = read.begin();
-        auto readEndIt = read.end();
+    auto rb = read.begin();
+    auto re = rb + k;
+    
+    uint32_t fwdHit{0};
+    uint32_t rcHit{0};
 
-        auto readRevStartIt = read.rbegin();
-        auto readRevEndIt = read.rend();
+    size_t fwdCov{0};
+    size_t rcCov{0};
 
-        auto rb = read.begin();
-        auto re = rb + k;
-        OffsetT lbLeftFwd = 0, ubLeftFwd = 0;
-        OffsetT lbLeftRC = 0, ubLeftRC = 0;
-        OffsetT lbRightFwd = 0, ubRightFwd = 0;
-        OffsetT lbRightRC = 0, ubRightRC = 0;
-        OffsetT matchedLen;
+    bool foundHit = false;
+    bool isRev = false;
 
-        uint32_t fwdHit{0};
-        uint32_t rcHit{0};
+    rapmap::utils::my_mer mer;
+    rapmap::utils::my_mer rcMer;
 
-        size_t fwdCov{0};
-        size_t rcCov{0};
-        bool foundHit = false;
-        bool isRev = false;
-        rapmap::utils::my_mer mer;
-        rapmap::utils::my_mer rcMer;
+    // This allows implementing our heurisic for comparing
+    // forward and reverse-complement strand matches
+    std::vector<KmerDirScore> kmerScores;
 
-        enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
-        // Record if k-mers are hits in the
-        // fwd direction, rc direction or both
-        struct KmerDirScore {
-	  KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn, HitStatus fwdScoreIn, HitStatus rcScoreIn) :
-	    kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn), rcScore(rcScoreIn) {}
-	  KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
-	  bool operator==(const KmerDirScore& other) const { return kpos == other.kpos; }
-	  bool operator<(const KmerDirScore& other) const { return kpos < other.kpos; }
-          void print() { 
-	    std::cerr << "{ " << kmer.to_str() << ", " <<  kpos << ", " << ((fwdScore) ? "PRESENT" : "ABSENT") << ", " << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
-	  }
-            rapmap::utils::my_mer kmer;
-	    int32_t kpos;
-            HitStatus fwdScore;
-            HitStatus rcScore;
-        };
+    using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
 
-        // This allows implementing our heurisic for comparing
-        // forward and reverse-complement strand matches
-        std::vector<KmerDirScore> kmerScores;
+    std::vector<SAIntervalHit> fwdSAInts;
+    std::vector<SAIntervalHit> rcSAInts;
 
-        using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
+    std::vector<uint32_t> leftTxps, leftTxpsRC;
+    std::vector<uint32_t> rightTxps, rightTxpsRC;
 
-        std::vector<SAIntervalHit> fwdSAInts;
-        std::vector<SAIntervalHit> rcSAInts;
+    // The number of bases that a new query position (to which
+    // we skipped) should overlap the previous extension. A
+    // value of 0 means no overlap (the new search begins at the next
+    // base) while a value of (k - 1) means that k-1 bases (one less than
+    // the k-mer size) must overlap.
 
-        std::vector<uint32_t> leftTxps, leftTxpsRC;
-        std::vector<uint32_t> rightTxps, rightTxpsRC;
-        OffsetT maxInterval{1000};
+    OffsetT skipOverlap = k-1;
+    //OffsetT skipOverlap = 0;
 
-        // The number of bases that a new query position (to which
-        // we skipped) should overlap the previous extension. A
-        // value of 0 means no overlap (the new search begins at the next
-        // base) while a value of (k - 1) means that k-1 bases (one less than
-        // the k-mer size) must overlap.
+    // Number of nucleotides to skip when encountering a homopolymer k-mer.
+    OffsetT homoPolymerSkip = k / 2;
+    auto merIt = hashEnd;
+    auto rcMerIt = hashEnd;
 
-        //OffsetT skipOverlap = k-1;
-        OffsetT skipOverlap = 0;
+    // Find a hit within the read
+    // While we haven't fallen off the end
+    while (re < read.end()) {
+      // Get the k-mer at the current start position.
+      // And make sure that it's valid (contains no Ns).
+      auto pos = std::distance(readStartIt, rb);
+      auto invalidPos = read.find_first_of("nN", pos);
+      if (invalidPos <= pos + k) {
+        rb = read.begin() + invalidPos + 1;
+        re = rb + k;
+        continue;
+      }
 
-        // Number of nucleotides to skip when encountering a homopolymer k-mer.
-        OffsetT homoPolymerSkip = k/2;
+      // If the next k-bases are valid, get the k-mer and
+      // reverse complement k-mer
+      mer = rapmap::utils::my_mer(read.c_str() + pos);
+      if (mer.is_homopolymer()) {
+        rb += homoPolymerSkip;
+        re += homoPolymerSkip;
+        continue;
+      }
+      rcMer = mer.get_reverse_complement();
 
-        // Find a hit within the read
-        // While we haven't fallen off the end
-        while (re < read.end()) {
+      // See if we can find this k-mer in the hash
+      merIt = khash.find(mer.get_bits(0, 2 * k));
+      rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
 
-            // Get the k-mer at the current start position.
-            // And make sure that it's valid (contains no Ns).
-            auto pos = std::distance(readStartIt, rb);
-            auto invalidPos = read.find_first_of("nN", pos);
-            if (invalidPos <= pos + k) {
-                rb = read.begin() + invalidPos + 1;
-                re = rb + k;
-                continue;
-            }
-
-            // If the next k-bases are valid, get the k-mer and
-            // reverse complement k-mer
-            mer = rapmap::utils::my_mer(read.c_str() + pos);
-            if (mer.is_homopolymer()) { rb += homoPolymerSkip; re += homoPolymerSkip; continue; }
-            rcMer = mer.get_reverse_complement();
-
-            // See if we can find this k-mer in the hash
-            auto merIt = khash.find(mer.get_bits(0, 2*k));
-            auto rcMerIt = khash.find(rcMer.get_bits(0, 2*k));
-
-            // If we can find the k-mer in the hash, get its SA interval
-            if (merIt != hashEnd) {
-                OffsetT lb = merIt->second.begin();
-                OffsetT ub = merIt->second.end();
-
-                // lb must be 1 *less* then the current lb
-                auto lbRestart = std::max(static_cast<OffsetT>(0), lb-1);
-                // Extend the SA interval using the read sequence as far as
-                // possible
-                std::tie(lbLeftFwd, ubLeftFwd, matchedLen) =
-                    saSearcher.extendSearchNaive(lbRestart, ub, k, rb, readEndIt);
-
-                // If the SA interval is valid, and not too wide, then record
-                // the hit.
-                OffsetT diff = ubLeftFwd - lbLeftFwd;
-                if (ubLeftFwd > lbLeftFwd and diff < maxInterval) {
-                    auto queryStart = std::distance(read.begin(), rb);
-                    fwdSAInts.emplace_back(lbLeftFwd, ubLeftFwd, matchedLen, queryStart, false);
-                    //iomutex_.lock();
-                    //std::cerr << "matchedLen = " << matchedLen << " (qp = " << queryStart << ")\n";
-                    //iomutex_.unlock();
-                    fwdCov += matchedLen;
-                    if (strictCheck) {
-                        ++fwdHit;
-                        // If we also match this k-mer in the rc direction
-			if (rcMerIt != hashEnd) {
-			  ++rcHit;
-			  kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
-			} else { // Otherwise it doesn't match in the rc direction
-			  kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
-			}
-
-			// If we didn't end the match b/c we exhausted the query
-                        // test the mismatching k-mer in the other strand
-                        // TODO: check for 'N'?
-                        if (rb + matchedLen < readEndIt){
-                            auto kmerPos = std::distance(readStartIt, rb + matchedLen - skipOverlap);
-                            mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-                            kmerScores.emplace_back(mer, kmerPos, ABSENT, UNTESTED);
-                        }
-                    } else { // no strict check
-                        ++fwdHit;
-                        if (rcMerIt != hashEnd) { ++rcHit; }
-                    }
-                }
-            }
-
-            // See if the reverse complement k-mer is in the hash
+      // If we can find the k-mer in the hash, get its SA interval
+      if (merIt != hashEnd) {
+          if (strictCheck) {
+            ++fwdHit;
+            // If we also match this k-mer in the rc direction
             if (rcMerIt != hashEnd) {
-                lbLeftRC = rcMerIt->second.begin();
-                ubLeftRC = rcMerIt->second.end();
-                OffsetT diff = ubLeftRC - lbLeftRC;
-                if (ubLeftRC > lbLeftRC) {
-                    // The original k-mer didn't match in the foward direction
-                    if (!fwdHit) {
-                        ++rcHit;
-                        if (strictCheck) {
-			  kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
-                        }
-                    }
-                }
+              ++rcHit;
+              kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
+            } else { // Otherwise it doesn't match in the rc direction
+              kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
             }
-
-            // If we had a hit with either k-mer then we can
-            // break out of this loop to look for the next informative position
-            if (fwdHit + rcHit > 0) {
-                foundHit = true;
-                break;
+          } else { // no strict check
+            ++fwdHit;
+            if (rcMerIt != hashEnd) {
+              ++rcHit;
             }
-            ++rb; ++re;
+          }
         }
 
-        // If we went the entire length of the read without finding a hit
-        // then we can bail.
-        if (!foundHit) { return false; }
+      // See if the reverse complement k-mer is in the hash
+      if (rcMerIt != hashEnd) {
+          // The original k-mer didn't match in the foward direction
+          if (!fwdHit) {
+              ++rcHit;
+              if (strictCheck) {
+                  kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
+              }
+          }
+      }
 
-        bool lastSearch{false};
-        // If we had a hit on the forward strand
-        if (fwdHit) {
-
-            // The length of this match
-            auto matchLen = fwdSAInts.front().len;
-            // The iterator to where this match began
-            rb = read.begin() + fwdSAInts.front().queryPos;
-
-            // [lb, ub) is the suffix array interval for the MMP (maximum mappable prefix)
-            // of the k-mer we found.  The NIP (next informative position) in the sequence
-            // is the position after the LCE (longest common extension) of
-            // T[SA[lb]:] and T[SA[ub-1]:]
-            auto remainingLength = std::distance(rb + matchLen, readEndIt);
-            auto lce = disableNIP_ ? matchLen : saSearcher.lce(lbLeftFwd, ubLeftFwd-1, matchLen, remainingLength);
-            auto fwdSkip = std::max(static_cast<OffsetT>(matchLen) - skipOverlap,
-                                    static_cast<OffsetT>(lce) - skipOverlap);
-
-            auto nipSkip = disableNIP_ ? 
-                static_cast<OffsetT>(readLen) : std::max(static_cast<OffsetT>(0), static_cast<OffsetT>(readLen)- static_cast<OffsetT>(k));
-            size_t nextInformativePosition = std::min(
-                                                      nipSkip , 
-                                                      static_cast<OffsetT>(std::distance(readStartIt, rb) + fwdSkip)
-                                                      );
-
-            rb = read.begin() + nextInformativePosition;
-            re = rb + k;
-
-            size_t invalidPos{0};
-            bool valid{true};
-            while (re <= readEndIt and valid) {
-                // The offset into the string
-                auto pos = std::distance(readStartIt, rb);
-
-                // The position of the first N in the k-mer (if there is one)
-                // If we have already verified there are no Ns in the remainder
-                // of the string (invalidPos is std::string::npos) then we can
-                // skip this test.
-                if (invalidPos != std::string::npos) {
-                    invalidPos = read.find_first_of("nN", pos);
-                }
-
-                // If the first N is within k bases, then this k-mer is invalid
-                if (invalidPos < pos + k) {
-                    // A valid k-mer can't start until after the 'N'
-                    nextInformativePosition = invalidPos + 1;
-                    rb = read.begin() + nextInformativePosition;
-                    re = rb + k;
-                    // Go to the next iteration of the while loop
-                    continue;
-                }
-
-                // If the current end position is valid
-                if (re <= readEndIt) {
-
-                    mer = rapmap::utils::my_mer(read.c_str() + pos);
-                    if (mer.is_homopolymer()) { rb += homoPolymerSkip; re = rb + k; continue; }
-                    auto merIt = khash.find(mer.get_bits(0, 2*k));
-
-                    if (merIt != hashEnd) {
-                        if (strictCheck) {
-                            ++fwdHit;
-                            kmerScores.emplace_back(mer, pos, PRESENT, UNTESTED);
-                            auto rcMer = mer.get_reverse_complement();
-                            auto rcMerIt = khash.find(rcMer.get_bits(0, 2*k));
-                            if (rcMerIt != hashEnd) {
-                                ++rcHit;
-                                kmerScores.back().rcScore = PRESENT;
-                            }
-                        }
-
-                        lbRightFwd = merIt->second.begin();
-                        ubRightFwd = merIt->second.end();
-
-                        // lb must be 1 *less* then the current lb
-                        lbRightFwd = std::max(static_cast<OffsetT>(0), lbRightFwd - 1);
-                        std::tie(lbRightFwd, ubRightFwd, matchedLen) =
-                            saSearcher.extendSearchNaive(lbRightFwd, ubRightFwd,
-                                    k, rb, readEndIt);
-
-                        OffsetT diff = ubRightFwd - lbRightFwd;
-                        if (ubRightFwd > lbRightFwd and diff < maxInterval) {
-                            auto queryStart = std::distance(read.begin(), rb);
-                            fwdSAInts.emplace_back(lbRightFwd, ubRightFwd, matchedLen, queryStart, false);
-                            //iomutex_.lock();
-                            //std::cerr << "matchedLen = " << matchedLen << " (qp = " << queryStart << ")\n";
-                            //iomutex_.unlock();
-                            fwdCov += matchedLen;
-                            // If we didn't end the match b/c we exhausted the query
-                            // test the mismatching k-mer in the other strand
-                            // TODO: check for 'N'?
-                            if (strictCheck and rb + matchedLen < readEndIt){
-                                auto kmerPos = std::distance(readStartIt, rb + matchedLen - skipOverlap);
-                                mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-				// TODO: 04/11/16
-                                kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
-                            }
-
-                        }
-
-                        if (lastSearch) { break; }
-                        auto mismatchIt = rb + matchedLen;
-                        if (mismatchIt < readEndIt) {
-                            auto remainingDistance = std::distance(mismatchIt, readEndIt);
-                            auto lce = disableNIP_ ? matchedLen : saSearcher.lce(lbRightFwd, ubRightFwd-1, matchedLen, remainingDistance);
-
-                            // Where we would jump if we just used the MMP
-                            auto skipMatch = mismatchIt - skipOverlap;
-                            // Where we would jump if we used the LCE
-                            auto skipLCE = rb + lce - skipOverlap;
-                            // Pick the larger of the two
-                            rb = std::max(skipLCE, skipMatch);
-                            if (rb > (readEndIt - k)) {
-                                rb = readEndIt - k;
-                                lastSearch = true;
-                                if (disableNIP_) { valid = false; }
-                            }
-                            re = rb + k;
-                        } else {
-                            lastSearch = true;
-                            rb = readEndIt - k;
-                            re = rb + k;
-                            if (disableNIP_) { valid = false; }
-                        }
-
-                    } else {
-                        rb += sampFactor;
-                        re = rb + k;
-                    }
-                }
-            }
-        }
-
-        lastSearch = false;
-        if (rcHit >= fwdHit) {
-            size_t pos{read.length() - k};
-
-            auto revReadEndIt = read.rend();
-
-            auto revRB = read.rbegin();
-            auto revRE = revRB + k;
-
-            auto invalidPosIt = revRB;
-            bool valid{true};
-            while (revRE <= revReadEndIt and valid){
-
-                revRE = revRB + k;
-                if (revRE > revReadEndIt) { break; }
-
-                // See if this k-mer would contain an N
-                // only check if we don't yet know that there are no remaining
-                // Ns
-                if (invalidPosIt != revReadEndIt) {
-                    invalidPosIt = std::find_if(revRB, revRE,
-                                                 [](const char c) -> bool {
-                                                     return c == 'n' or c == 'N';
-                                                 });
-                }
-
-                // If we found an N before the end of the k-mer
-                if (invalidPosIt < revRE) {
-                    // Skip to the k-mer starting at the next position
-                    // (i.e. right past the N)
-                    revRB = invalidPosIt + 1;
-                    continue;
-                }
-
-                // The distance from the beginning of the read to the
-                // start of the k-mer
-                pos = std::distance(revRE, revReadEndIt);
-
-                // Get the k-mer and query it in the hash
-                mer = rapmap::utils::my_mer(read.c_str() + pos);
-                if (mer.is_homopolymer()) { revRB += homoPolymerSkip; revRE += homoPolymerSkip; continue; }
-                rcMer = mer.get_reverse_complement();
-                auto rcMerIt = khash.find(rcMer.get_bits(0, 2*k));
-
-                // If we found the k-mer
-                if (rcMerIt != hashEnd) {
-                    if (strictCheck) {
-                        ++rcHit;
-                        kmerScores.emplace_back(mer, pos, UNTESTED, PRESENT);
-                        auto merIt = khash.find(mer.get_bits(0, 2*k));
-                        if (merIt != hashEnd) {
-                            ++fwdHit;
-                            kmerScores.back().fwdScore = PRESENT;
-                        }
-                    }
-
-
-                    lbRightRC = rcMerIt->second.begin();
-                    ubRightRC = rcMerIt->second.end();
-
-                    // lb must be 1 *less* then the current lb
-                    // We can't move any further in the reverse complement direction
-                    lbRightRC = std::max(static_cast<OffsetT>(0), lbRightRC - 1);
-                    std::tie(lbRightRC, ubRightRC, matchedLen) =
-                        saSearcher.extendSearchNaive(lbRightRC, ubRightRC, k,
-                                revRB, revReadEndIt, true);
-
-                    OffsetT diff = ubRightRC - lbRightRC;
-                    if (ubRightRC > lbRightRC and diff < maxInterval) {
-                        auto queryStart = std::distance(read.rbegin(), revRB);
-                        rcSAInts.emplace_back(lbRightRC, ubRightRC, matchedLen, queryStart, true);
-                        rcCov += matchedLen;
-                        // If we didn't end the match b/c we exhausted the query
-                        // test the mismatching k-mer in the other strand
-                        // TODO: check for 'N'?
-                        if (strictCheck and revRB + matchedLen < revReadEndIt){
-                            auto kmerPos = std::distance(revRB + matchedLen, revReadEndIt);
-                            mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-                            // TODO: 04/11/16
-                            kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
-                        }
-                    }
-
-                    if (lastSearch) { break; }
-                    auto mismatchIt = revRB + matchedLen;
-                    if (mismatchIt < revReadEndIt) {
-                        auto remainingDistance = std::distance(mismatchIt, revReadEndIt);
-                        auto lce = disableNIP_ ? matchedLen : saSearcher.lce(lbRightRC, ubRightRC-1, matchedLen, remainingDistance);
-
-                        // Where we would jump if we just used the MMP
-                        auto skipMatch = mismatchIt - skipOverlap;
-                        // Where we would jump if we used the lce
-                        auto skipLCE = revRB + lce - skipOverlap;
-                        // Choose the larger of the two
-                        revRB = std::max(skipLCE, skipMatch);
-                        if (revRB > (revReadEndIt - k)) {
-                            revRB = revReadEndIt - k;
-                            lastSearch = true;
-                            if (disableNIP_) { valid = false; }
-                        }
-                        revRE = revRB + k;
-                    } else {
-                        lastSearch = true;
-                        revRB = revReadEndIt - k;
-                        revRE = revRB + k;
-                        if (disableNIP_) { valid = false; }
-                    }
-
-                } else {
-                    revRB += sampFactor;
-                    revRE = revRB + k;
-                }
-            }
-        }
-
-        if (strictCheck) {
-            // The first two conditions shouldn't happen
-            // but I'm just being paranoid here
-            if (fwdHit > 0 and rcHit == 0) {
-                rcSAInts.clear();
-            } else if (rcHit > 0 and fwdHit == 0) {
-                fwdSAInts.clear();
-            } else {
-	      std::sort( kmerScores.begin(), kmerScores.end() );
-	      auto e = std::unique(kmerScores.begin(), kmerScores.end());
-                // Compute the score for the k-mers we need to
-                // test in both the forward and rc directions.
-                int32_t fwdScore{0};
-                int32_t rcScore{0};
-                // For every kmer score structure
-		//std::cerr << "[\n";
-                for (auto kmsIt = kmerScores.begin(); kmsIt != e; ++kmsIt) {//: kmerScores) {
-   		    auto& kms = *kmsIt;
-                    // If the forward k-mer is untested, then test it
-                    if (kms.fwdScore == UNTESTED) {
-                        auto merIt = khash.find(kms.kmer.get_bits(0, 2*k));
-                        kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
-                    }
-                    // accumulate the score
-                    fwdScore += kms.fwdScore;
-
-                    // If the rc k-mer is untested, then test it
-                    if (kms.rcScore == UNTESTED) {
-                        rcMer = kms.kmer.get_reverse_complement();
-                        auto rcMerIt = khash.find(rcMer.get_bits(0, 2*k));
-                        kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
-                    }
-                    // accumulate the score
-                    rcScore += kms.rcScore;
-		    //kms.print();
-		    //std::cerr << "\n";
-                }
-		//std::cerr << "]\n";
-                // If the forward score is strictly greater
-                // then get rid of the rc hits.
-                if (fwdScore > rcScore) {
-                    rcSAInts.clear();
-                } else if (rcScore > fwdScore) {
-                    // If the rc score is strictly greater
-                    // get rid of the forward hits
-                    fwdSAInts.clear();
-                }
-            }
-        }
-
-        if (covReq_ > 0.0) {
-            double fwdFrac{0.0};
-            double rcFrac{0.0};
-            if (fwdSAInts.size() > 0) {
-                fwdFrac  = fwdCov / static_cast<double>(readLen);
-                if (fwdFrac < covReq_) { fwdSAInts.clear(); }
-            }
-            if (rcSAInts.size() > 0) {
-                rcFrac = rcCov / static_cast<double>(readLen);
-                if (rcFrac < covReq_) { rcSAInts.clear(); }
-            }
-            /*
-            if (fwdFrac + rcFrac > 0.0) {
-                iomutex_.lock();
-                std::cerr << fwdFrac << ", " << rcFrac << "\n";
-                iomutex_.unlock();
-            }
-            */
-        }
-
-        auto fwdHitsStart = hits.size();
-        // If we had > 1 forward hit
-        if (fwdSAInts.size() > 1) {
-            auto processedHits = rapmap::hit_manager::intersectSAHits(fwdSAInts, *rmi_, readLen, consistentHits);
-            rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist, hits, mateStatus);
-        } else if (fwdSAInts.size() == 1) { // only 1 hit!
-            auto& saIntervalHit = fwdSAInts.front();
-                auto initialSize = hits.size();
-                for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
-                        auto globalPos = SA[i];
-		            	auto txpID = rmi_->transcriptAtPosition(globalPos);
-                        // the offset into this transcript
-                        auto pos = globalPos - txpStarts[txpID];
-                        int32_t hitPos = pos - saIntervalHit.queryPos;
-                        hits.emplace_back(txpID, hitPos, true, readLen);
-                        hits.back().mateStatus = mateStatus;
-                }
-                // Now sort by transcript ID (then position) and eliminate
-                // duplicates
-                auto sortStartIt = hits.begin() + initialSize;
-                auto sortEndIt = hits.end();
-                std::sort(sortStartIt, sortEndIt,
-                                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                                if (a.tid == b.tid) {
-                                return a.pos < b.pos;
-                                } else {
-                                return a.tid < b.tid;
-                                }
-                                });
-                auto newEnd = std::unique(hits.begin() + initialSize, hits.end(),
-                                [] (const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                                return a.tid == b.tid;
-                                });
-                hits.resize(std::distance(hits.begin(), newEnd));
-        }
-        auto fwdHitsEnd = hits.size();
-
-        auto rcHitsStart = fwdHitsEnd;
-        // If we had > 1 rc hit
-        if (rcSAInts.size() > 1) {
-            auto processedHits = rapmap::hit_manager::intersectSAHits(rcSAInts, *rmi_, readLen, consistentHits);
-            rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist, hits, mateStatus);
-        } else if (rcSAInts.size() == 1) { // only 1 hit!
-            auto& saIntervalHit = rcSAInts.front();
-            auto initialSize = hits.size();
-            for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
-                auto globalPos = SA[i];
-		        auto txpID = rmi_->transcriptAtPosition(globalPos);
-                // the offset into this transcript
-                auto pos = globalPos - txpStarts[txpID];
-                int32_t hitPos = pos - saIntervalHit.queryPos;
-                hits.emplace_back(txpID, hitPos, false, readLen);
-                hits.back().mateStatus = mateStatus;
-            }
-            // Now sort by transcript ID (then position) and eliminate
-            // duplicates
-            auto sortStartIt = hits.begin() + rcHitsStart;
-            auto sortEndIt = hits.end();
-            std::sort(sortStartIt, sortEndIt,
-                    [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                    if (a.tid == b.tid) {
-                    return a.pos < b.pos;
-                    } else {
-                    return a.tid < b.tid;
-                    }
-                    });
-            auto newEnd = std::unique(sortStartIt, sortEndIt,
-                    [] (const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                    return a.tid == b.tid;
-                    });
-            hits.resize(std::distance(hits.begin(), newEnd));
-        }
-        auto rcHitsEnd = hits.size();
-
-        // If we had both forward and RC hits, then merge them
-        if ((fwdHitsEnd > fwdHitsStart) and (rcHitsEnd > rcHitsStart)) {
-            // Merge the forward and reverse hits
-            std::inplace_merge(hits.begin() + fwdHitsStart, hits.begin() + fwdHitsEnd, hits.begin() + rcHitsEnd,
-                    [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                    return a.tid < b.tid;
-                    });
-            // And get rid of duplicate transcript IDs
-            auto newEnd = std::unique(hits.begin() + fwdHitsStart, hits.begin() + rcHitsEnd,
-                    [] (const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                    return a.tid == b.tid;
-                    });
-            hits.resize(std::distance(hits.begin(), newEnd));
-        }
-        // Return true if we had any valid hits and false otherwise.
-        return foundHit;
+      // If we had a hit with either k-mer then we can
+      // break out of this loop to look for the next informative position
+      if (fwdHit + rcHit > 0) {
+        foundHit = true;
+        break;
+      }
+      ++rb;
+      ++re;
     }
 
-    private:
-        RapMapIndexT* rmi_;
-    bool disableNIP_{false};
-    double covReq_{0.0};
-    std::mutex iomutex_;
+    // If we went the entire length of the read without finding a hit
+    // then we can bail.
+    if (!foundHit) {
+      return false;
+    }
+
+    // If we had a hit on the forward strand
+    if (fwdHit) {
+        getSAHits_(
+                  saSearcher,
+                  read, // the read
+                  rb, // where to start the search
+                  &(merIt->second), // pointer to the search interval
+                  fwdCov,
+                  fwdHit,
+                  rcHit,
+                  fwdSAInts,
+                  kmerScores,
+                  false);
+    }
+
+    if (rcHit >= fwdHit) {
+        rapmap::utils::reverseRead(read, rcBuffer_);
+        getSAHits_(
+                  saSearcher,
+                  rcBuffer_, // the read
+                  rcBuffer_.begin(), // where to start the search
+                  nullptr, // pointer to the search interval
+                  rcCov,
+                  rcHit,
+                  fwdHit,
+                  rcSAInts,
+                  kmerScores,
+                  true);
+    }
+
+    if (strictCheck) {
+      // The first two conditions shouldn't happen
+      // but I'm just being paranoid here
+      if (fwdHit > 0 and rcHit == 0) {
+        rcSAInts.clear();
+      } else if (rcHit > 0 and fwdHit == 0) {
+        fwdSAInts.clear();
+      } else {
+        std::sort(kmerScores.begin(), kmerScores.end());
+        auto e = std::unique(kmerScores.begin(), kmerScores.end());
+        // Compute the score for the k-mers we need to
+        // test in both the forward and rc directions.
+        int32_t fwdScore{0};
+        int32_t rcScore{0};
+        // For every kmer score structure
+        // std::cerr << "[\n";
+        for (auto kmsIt = kmerScores.begin(); kmsIt != e;
+             ++kmsIt) { //: kmerScores) {
+          auto& kms = *kmsIt;
+          // If the forward k-mer is untested, then test it
+          if (kms.fwdScore == UNTESTED) {
+            auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
+            kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
+          }
+          // accumulate the score
+          fwdScore += kms.fwdScore;
+
+          // If the rc k-mer is untested, then test it
+          if (kms.rcScore == UNTESTED) {
+            rcMer = kms.kmer.get_reverse_complement();
+            auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+            kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
+          }
+          // accumulate the score
+          rcScore += kms.rcScore;
+          // kms.print();
+          // std::cerr << "\n";
+        }
+        // std::cerr << "]\n";
+        // If the forward score is strictly greater
+        // then get rid of the rc hits.
+        if (fwdScore > rcScore) {
+          rcSAInts.clear();
+        } else if (rcScore > fwdScore) {
+          // If the rc score is strictly greater
+          // get rid of the forward hits
+          fwdSAInts.clear();
+        }
+      }
+    }
+
+    // Coverage requirements only make sense if
+    // we have disabled NIP skipping.
+    if (covReq_ > 0.0 and disableNIP_) {
+      double fwdFrac{0.0};
+      double rcFrac{0.0};
+      if (fwdSAInts.size() > 0) {
+        fwdFrac = fwdCov / static_cast<double>(readLen);
+        if (fwdFrac < covReq_) {
+          fwdSAInts.clear();
+        }
+      }
+      if (rcSAInts.size() > 0) {
+        rcFrac = rcCov / static_cast<double>(readLen);
+        if (rcFrac < covReq_) {
+          rcSAInts.clear();
+        }
+      }
+      /*
+      if (fwdFrac + rcFrac > 0.0) {
+          iomutex_.lock();
+          std::cerr << fwdFrac << ", " << rcFrac << "\n";
+          iomutex_.unlock();
+      }
+      */
+    }
+
+    auto fwdHitsStart = hits.size();
+    // If we had > 1 forward hit
+    if (fwdSAInts.size() > 1) {
+      auto processedHits = rapmap::hit_manager::intersectSAHits(
+          fwdSAInts, *rmi_, readLen, consistentHits);
+      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
+                                               hits, mateStatus);
+    } else if (fwdSAInts.size() == 1) { // only 1 hit!
+      auto& saIntervalHit = fwdSAInts.front();
+      auto initialSize = hits.size();
+      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
+        auto globalPos = SA[i];
+        auto txpID = rmi_->transcriptAtPosition(globalPos);
+        // the offset into this transcript
+        auto pos = globalPos - txpStarts[txpID];
+        int32_t hitPos = pos - saIntervalHit.queryPos;
+        hits.emplace_back(txpID, hitPos, true, readLen);
+        hits.back().mateStatus = mateStatus;
+      }
+      // Now sort by transcript ID (then position) and eliminate
+      // duplicates
+      auto sortStartIt = hits.begin() + initialSize;
+      auto sortEndIt = hits.end();
+      std::sort(sortStartIt, sortEndIt,
+                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+                  if (a.tid == b.tid) {
+                    return a.pos < b.pos;
+                  } else {
+                    return a.tid < b.tid;
+                  }
+                });
+      auto newEnd = std::unique(
+          hits.begin() + initialSize, hits.end(),
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    auto fwdHitsEnd = hits.size();
+
+    auto rcHitsStart = fwdHitsEnd;
+    // If we had > 1 rc hit
+    if (rcSAInts.size() > 1) {
+      auto processedHits = rapmap::hit_manager::intersectSAHits(
+          rcSAInts, *rmi_, readLen, consistentHits);
+      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
+                                               hits, mateStatus);
+    } else if (rcSAInts.size() == 1) { // only 1 hit!
+      auto& saIntervalHit = rcSAInts.front();
+      auto initialSize = hits.size();
+      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
+        auto globalPos = SA[i];
+        auto txpID = rmi_->transcriptAtPosition(globalPos);
+        // the offset into this transcript
+        auto pos = globalPos - txpStarts[txpID];
+        int32_t hitPos = pos - saIntervalHit.queryPos;
+        hits.emplace_back(txpID, hitPos, false, readLen);
+        hits.back().mateStatus = mateStatus;
+      }
+      // Now sort by transcript ID (then position) and eliminate
+      // duplicates
+      auto sortStartIt = hits.begin() + rcHitsStart;
+      auto sortEndIt = hits.end();
+      std::sort(sortStartIt, sortEndIt,
+                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+                  if (a.tid == b.tid) {
+                    return a.pos < b.pos;
+                  } else {
+                    return a.tid < b.tid;
+                  }
+                });
+      auto newEnd = std::unique(
+          sortStartIt, sortEndIt,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    auto rcHitsEnd = hits.size();
+
+    // If we had both forward and RC hits, then merge them
+    if ((fwdHitsEnd > fwdHitsStart) and (rcHitsEnd > rcHitsStart)) {
+      // Merge the forward and reverse hits
+      std::inplace_merge(
+          hits.begin() + fwdHitsStart, hits.begin() + fwdHitsEnd,
+          hits.begin() + rcHitsEnd,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid < b.tid;
+          });
+      // And get rid of duplicate transcript IDs
+      auto newEnd = std::unique(
+          hits.begin() + fwdHitsStart, hits.begin() + rcHitsEnd,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    // Return true if we had any valid hits and false otherwise.
+    return foundHit;
+    }
+
+  /** Find the mappings for a read **/
+  bool oldOperator(std::string& read,
+                  std::vector<rapmap::utils::QuasiAlignment>& hits,
+                  SASearcher<RapMapIndexT>& saSearcher,
+                  rapmap::utils::MateStatus mateStatus,
+                  bool strictCheck = false, bool consistentHits = false) {
+
+    using QuasiAlignment = rapmap::utils::QuasiAlignment;
+    using MateStatus = rapmap::utils::MateStatus;
+
+    auto& rankDict = rmi_->rankDict;
+    auto& txpStarts = rmi_->txpOffsets;
+    auto& SA = rmi_->SA;
+    auto& khash = rmi_->khash;
+    auto& text = rmi_->seq;
+    uint32_t sampFactor{1};
+    auto salen = SA.size();
+    auto hashEnd = khash.end();
+
+    auto readLen = read.length();
+    auto maxDist = 1.5 * readLen;
+    auto k = rapmap::utils::my_mer::k();
+    auto readStartIt = read.begin();
+    auto readEndIt = read.end();
+
+    auto readRevStartIt = read.rbegin();
+    auto readRevEndIt = read.rend();
+
+    auto rb = read.begin();
+    auto re = rb + k;
+    // Were the last "rightmost" hit ended on the query
+    auto prevHitTail = read.begin();
+    
+    OffsetT lbLeftFwd = 0, ubLeftFwd = 0;
+    OffsetT lbLeftRC = 0, ubLeftRC = 0;
+    OffsetT lbRightFwd = 0, ubRightFwd = 0;
+    OffsetT lbRightRC = 0, ubRightRC = 0;
+    OffsetT matchedLen;
+
+    uint32_t fwdHit{0};
+    uint32_t rcHit{0};
+
+    size_t fwdCov{0};
+    size_t rcCov{0};
+    bool foundHit = false;
+    bool isRev = false;
+    rapmap::utils::my_mer mer;
+    rapmap::utils::my_mer rcMer;
+
+    enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
+    // Record if k-mers are hits in the
+    // fwd direction, rc direction or both
+    struct KmerDirScore {
+      KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn,
+                   HitStatus fwdScoreIn, HitStatus rcScoreIn)
+          : kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn),
+            rcScore(rcScoreIn) {}
+      KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
+      bool operator==(const KmerDirScore& other) const {
+        return kpos == other.kpos;
+      }
+      bool operator<(const KmerDirScore& other) const {
+        return kpos < other.kpos;
+      }
+      void print() {
+        std::cerr << "{ " << kmer.to_str() << ", " << kpos << ", "
+                  << ((fwdScore) ? "PRESENT" : "ABSENT") << ", "
+                  << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
+      }
+      rapmap::utils::my_mer kmer;
+      int32_t kpos;
+      HitStatus fwdScore;
+      HitStatus rcScore;
+    };
+
+    // This allows implementing our heurisic for comparing
+    // forward and reverse-complement strand matches
+    std::vector<KmerDirScore> kmerScores;
+
+    using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
+
+    std::vector<SAIntervalHit> fwdSAInts;
+    std::vector<SAIntervalHit> rcSAInts;
+
+    std::vector<uint32_t> leftTxps, leftTxpsRC;
+    std::vector<uint32_t> rightTxps, rightTxpsRC;
+
+    // The number of bases that a new query position (to which
+    // we skipped) should overlap the previous extension. A
+    // value of 0 means no overlap (the new search begins at the next
+    // base) while a value of (k - 1) means that k-1 bases (one less than
+    // the k-mer size) must overlap.
+
+    OffsetT skipOverlap = k-1;
+    //OffsetT skipOverlap = 0;
+
+    // Number of nucleotides to skip when encountering a homopolymer k-mer.
+    OffsetT homoPolymerSkip = k / 2;
+
+    // Find a hit within the read
+    // While we haven't fallen off the end
+    while (re < read.end()) {
+
+      // Get the k-mer at the current start position.
+      // And make sure that it's valid (contains no Ns).
+      auto pos = std::distance(readStartIt, rb);
+      auto invalidPos = read.find_first_of("nN", pos);
+      if (invalidPos <= pos + k) {
+        rb = read.begin() + invalidPos + 1;
+        re = rb + k;
+        continue;
+      }
+
+      // If the next k-bases are valid, get the k-mer and
+      // reverse complement k-mer
+      mer = rapmap::utils::my_mer(read.c_str() + pos);
+      if (mer.is_homopolymer()) {
+        rb += homoPolymerSkip;
+        re += homoPolymerSkip;
+        continue;
+      }
+      rcMer = mer.get_reverse_complement();
+
+      // See if we can find this k-mer in the hash
+      auto merIt = khash.find(mer.get_bits(0, 2 * k));
+      auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+
+      // If we can find the k-mer in the hash, get its SA interval
+      if (merIt != hashEnd) {
+        OffsetT lb = merIt->second.begin();
+        OffsetT ub = merIt->second.end();
+
+        // lb must be 1 *less* then the current lb
+        auto lbRestart = std::max(static_cast<OffsetT>(0), lb - 1);
+
+        // Extend the SA interval using the read sequence as far as
+        // possible
+        std::tie(lbLeftFwd, ubLeftFwd, matchedLen) =
+            saSearcher.extendSearchNaive(lbRestart, ub, k, rb, readEndIt);
+
+        // If the SA interval is valid, and not too wide, then record
+        // the hit.
+        OffsetT diff = ubLeftFwd - lbLeftFwd;
+        if (ubLeftFwd > lbLeftFwd and diff < maxInterval_) {
+          auto queryStart = std::distance(read.begin(), rb);
+          fwdSAInts.emplace_back(lbLeftFwd, ubLeftFwd, matchedLen, queryStart,
+                                 false);
+          // iomutex_.lock();
+          // std::cerr << "matchedLen = " << matchedLen << " (qp = " <<
+          // queryStart << ")\n";
+          // iomutex_.unlock();
+          fwdCov += matchedLen;
+          if (strictCheck) {
+            ++fwdHit;
+            // If we also match this k-mer in the rc direction
+            if (rcMerIt != hashEnd) {
+              ++rcHit;
+              kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
+            } else { // Otherwise it doesn't match in the rc direction
+              kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
+            }
+
+            // If we didn't end the match b/c we exhausted the query
+            // test the mismatching k-mer in the other strand
+            // TODO: check for 'N'?
+            if (rb + matchedLen < readEndIt) {
+              auto kmerPos =
+                  std::distance(readStartIt, rb + matchedLen - skipOverlap);
+              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
+              kmerScores.emplace_back(mer, kmerPos, ABSENT, UNTESTED);
+            }
+          } else { // no strict check
+            ++fwdHit;
+            if (rcMerIt != hashEnd) {
+              ++rcHit;
+            }
+          }
+        }
+      }
+
+      // See if the reverse complement k-mer is in the hash
+      if (rcMerIt != hashEnd) {
+        lbLeftRC = rcMerIt->second.begin();
+        ubLeftRC = rcMerIt->second.end();
+        OffsetT diff = ubLeftRC - lbLeftRC;
+        if (ubLeftRC > lbLeftRC) {
+          // The original k-mer didn't match in the foward direction
+          if (!fwdHit) {
+            ++rcHit;
+            if (strictCheck) {
+              kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
+            }
+          }
+        }
+      }
+
+      // If we had a hit with either k-mer then we can
+      // break out of this loop to look for the next informative position
+      if (fwdHit + rcHit > 0) {
+        foundHit = true;
+        break;
+      }
+      ++rb;
+      ++re;
+    }
+
+    // If we went the entire length of the read without finding a hit
+    // then we can bail.
+    if (!foundHit) {
+      return false;
+    }
+
+    bool lastSearch{false};
+    // If we had a hit on the forward strand
+    if (fwdHit) {
+
+      // The length of this match
+      auto matchLen = fwdSAInts.front().len;
+      // The iterator to where this match began
+      rb = read.begin() + fwdSAInts.front().queryPos;
+
+      // How much of the sequence is left after the
+      // end of our match.
+      auto remainingLength = std::distance(rb + matchLen, readEndIt);
+
+      // We haven't done LCE yet, so any match here is "verified".
+      // If we're fewer than k bases from the end, don't bother to
+      // do any more work in this branch.
+      if (remainingLength < k) { goto doneFwd; }
+      
+      // [lb, ub) is the suffix array interval for the MMP (maximum mappable
+      // prefix) of the k-mer we found.  The NIP (next informative position)
+      // in the sequence is the position after
+      // the LCE (longest common extension) of T[SA[lb]:] and T[SA[ub-1]:]
+
+      // If NIP skipping is disabled, then just treat the NIP as the MMP.
+      auto lce = disableNIP_ ? matchLen
+                             : saSearcher.lce(lbLeftFwd, ubLeftFwd - 1,
+                                              matchLen, remainingLength);
+
+      auto fwdSkip = std::max(static_cast<OffsetT>(matchLen) - skipOverlap,
+                              static_cast<OffsetT>(lce) - skipOverlap);
+
+      // The maximum position at which we could start our next search.
+      size_t maxPos = static_cast<OffsetT>(std::distance(readStartIt, rb) + fwdSkip);
+      size_t nextInformativePosition = maxPos;
+
+      
+      // If NIP skipping is *enabled*, and we got to the current position
+      // by doing an LCE query, then we allow ourselves to *double check*
+      // by querying the last k-mer in the read.
+      // Otherwise, we just take the skip we're given.
+      OffsetT nipSkip;
+      if (!disableNIP_ and (lce > matchLen)) {
+	size_t lastKmerPos = std::max(static_cast<OffsetT>(0),
+				    static_cast<OffsetT>(readLen) - static_cast<OffsetT>(k));
+	nextInformativePosition = std::min(lastKmerPos, nextInformativePosition);
+      } 
+
+      /*
+      auto nipSkip = disableNIP_ ? static_cast<OffsetT>(readLen)
+                                 : std::max(static_cast<OffsetT>(0),
+                                            static_cast<OffsetT>(readLen) -
+                                                static_cast<OffsetT>(k));
+      size_t nextInformativePosition = std::min(
+          nipSkip,
+          static_cast<OffsetT>(std::distance(readStartIt, rb) + fwdSkip));
+      */
+      
+      rb = read.begin() + nextInformativePosition;
+      re = rb + k;
+
+      size_t invalidPos{0};
+      while (re <= readEndIt) {
+        // The offset into the string
+        auto pos = std::distance(readStartIt, rb);
+
+        // The position of the first N in the k-mer (if there is one)
+        // If we have already verified there are no Ns in the remainder
+        // of the string (invalidPos is std::string::npos) then we can
+        // skip this test.
+        if (invalidPos != std::string::npos) {
+          invalidPos = read.find_first_of("nN", pos);
+        }
+
+        // If the first N is within k bases, then this k-mer is invalid
+        if (invalidPos < pos + k) {
+          // A valid k-mer can't start until after the 'N'
+          nextInformativePosition = invalidPos + 1;
+          rb = read.begin() + nextInformativePosition;
+          re = rb + k;
+          // Go to the next iteration of the while loop
+          continue;
+        }
+
+        // If the current end position is valid
+        if (re <= readEndIt) {
+
+          mer = rapmap::utils::my_mer(read.c_str() + pos);
+          if (mer.is_homopolymer()) {
+            rb += homoPolymerSkip;
+            re = rb + k;
+            continue;
+          }
+          auto merIt = khash.find(mer.get_bits(0, 2 * k));
+
+          if (merIt != hashEnd) {
+            if (strictCheck) {
+              ++fwdHit;
+              kmerScores.emplace_back(mer, pos, PRESENT, UNTESTED);
+              auto rcMer = mer.get_reverse_complement();
+              auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+              if (rcMerIt != hashEnd) {
+                ++rcHit;
+                kmerScores.back().rcScore = PRESENT;
+              }
+            }
+
+            lbRightFwd = merIt->second.begin();
+            ubRightFwd = merIt->second.end();
+
+            // lb must be 1 *less* then the current lb
+            lbRightFwd = std::max(static_cast<OffsetT>(0), lbRightFwd - 1);
+            std::tie(lbRightFwd, ubRightFwd, matchedLen) =
+                saSearcher.extendSearchNaive(lbRightFwd, ubRightFwd, k, rb,
+                                             readEndIt);
+
+            OffsetT diff = ubRightFwd - lbRightFwd;
+            if (ubRightFwd > lbRightFwd and diff < maxInterval_) {
+              auto queryStart = std::distance(read.begin(), rb);
+              fwdSAInts.emplace_back(lbRightFwd, ubRightFwd, matchedLen,
+                                     queryStart, false);
+              // iomutex_.lock();
+              // std::cerr << "matchedLen = " << matchedLen << " (qp = " <<
+              // queryStart << ")\n";
+              // iomutex_.unlock();
+              fwdCov += matchedLen;
+              // If we didn't end the match b/c we exhausted the query
+              // test the mismatching k-mer in the other strand
+              // TODO: check for 'N'?
+              if (strictCheck and rb + matchedLen < readEndIt) {
+                auto kmerPos =
+                    std::distance(readStartIt, rb + matchedLen - skipOverlap);
+                mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
+                // TODO: 04/11/16
+                kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
+              }
+            }
+
+            if (lastSearch) {
+              break;
+            }
+            auto mismatchIt = rb + matchedLen;
+            if (mismatchIt < readEndIt) {
+              auto remainingDistance = std::distance(mismatchIt, readEndIt);
+              auto lce = disableNIP_
+                             ? matchedLen
+                             : saSearcher.lce(lbRightFwd, ubRightFwd - 1,
+                                              matchedLen, remainingDistance);
+
+	      // Where we would jump if we just used the MMP
+	      auto skipMatch = mismatchIt - skipOverlap;
+	      // Where we would jump if we used the LCE
+	      auto skipLCE = rb + lce - skipOverlap;
+
+	      auto maxSkip = std::max(skipMatch, skipLCE);
+	      rb = maxSkip;
+	      
+	      // If NIP skipping is *enabled*, and we got to the current position
+	      // by doing an LCE query, then we allow ourselves to *double check*
+	      // by querying the last k-mer in the read.
+	      // Otherwise, we just take the skip we're given.
+	      if (!disableNIP_ and (lce > matchLen)) {
+		if (readLen > k) {
+		  rb = std::min(readEndIt - k, rb);
+		}
+	      } 
+	      /* 
+              if (rb > (readEndIt - k)) {
+                rb = readEndIt - k;
+                lastSearch = true;
+                if (disableNIP_) {
+                  valid = false;
+                }
+              }
+	      */
+              re = rb + k;
+	      if (re == readEndIt) { lastSearch = true; }
+
+            } else {
+	      /*
+              lastSearch = true;
+              rb = readEndIt - k;
+              re = rb + k;
+              if (disableNIP_) {
+                valid = false;
+              }
+	      */
+	      goto doneFwd;
+            }
+
+          } else {
+            rb += sampFactor;
+            re = rb + k;
+          }
+        }
+      }
+    }
+  doneFwd:
+
+    lastSearch = false;
+    if (rcHit >= fwdHit) {
+      size_t pos{read.length() - k};
+
+      auto revReadEndIt = read.rend();
+
+      auto revRB = read.rbegin();
+      auto revRE = revRB + k;
+
+      auto invalidPosIt = revRB;
+      while (revRE <= revReadEndIt) {
+
+        revRE = revRB + k;
+        if (revRE > revReadEndIt) {
+          break;
+        }
+
+        // See if this k-mer would contain an N
+        // only check if we don't yet know that there are no remaining
+        // Ns
+        if (invalidPosIt != revReadEndIt) {
+          invalidPosIt = std::find_if(revRB, revRE, [](const char c) -> bool {
+            return c == 'n' or c == 'N';
+          });
+        }
+
+        // If we found an N before the end of the k-mer
+        if (invalidPosIt < revRE) {
+          // Skip to the k-mer starting at the next position
+          // (i.e. right past the N)
+          revRB = invalidPosIt + 1;
+          continue;
+        }
+
+        // The distance from the beginning of the read to the
+        // start of the k-mer
+        pos = std::distance(revRE, revReadEndIt);
+
+        // Get the k-mer and query it in the hash
+        mer = rapmap::utils::my_mer(read.c_str() + pos);
+        if (mer.is_homopolymer()) {
+          revRB += homoPolymerSkip;
+          revRE += homoPolymerSkip;
+          continue;
+        }
+        rcMer = mer.get_reverse_complement();
+        auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+
+        // If we found the k-mer
+        if (rcMerIt != hashEnd) {
+          if (strictCheck) {
+            ++rcHit;
+            kmerScores.emplace_back(mer, pos, UNTESTED, PRESENT);
+            auto merIt = khash.find(mer.get_bits(0, 2 * k));
+            if (merIt != hashEnd) {
+              ++fwdHit;
+              kmerScores.back().fwdScore = PRESENT;
+            }
+          }
+
+          lbRightRC = rcMerIt->second.begin();
+          ubRightRC = rcMerIt->second.end();
+
+          // lb must be 1 *less* then the current lb
+          // We can't move any further in the reverse complement direction
+          lbRightRC = std::max(static_cast<OffsetT>(0), lbRightRC - 1);
+          std::tie(lbRightRC, ubRightRC, matchedLen) =
+              saSearcher.extendSearchNaive(lbRightRC, ubRightRC, k, revRB,
+                                           revReadEndIt, true);
+
+          OffsetT diff = ubRightRC - lbRightRC;
+          if (ubRightRC > lbRightRC and diff < maxInterval_) {
+            auto queryStart = std::distance(read.rbegin(), revRB);
+            rcSAInts.emplace_back(lbRightRC, ubRightRC, matchedLen, queryStart,
+                                  true);
+            rcCov += matchedLen;
+            // If we didn't end the match b/c we exhausted the query
+            // test the mismatching k-mer in the other strand
+            // TODO: check for 'N'?
+            if (strictCheck and revRB + matchedLen < revReadEndIt) {
+              auto kmerPos = std::distance(revRB + matchedLen, revReadEndIt);
+              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
+              // TODO: 04/11/16
+              kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
+            }
+          }
+
+          if (lastSearch) {
+            break;
+          }
+          auto mismatchIt = revRB + matchedLen;
+          if (mismatchIt < revReadEndIt) {
+            auto remainingDistance = std::distance(mismatchIt, revReadEndIt);
+            auto lce = disableNIP_
+                           ? matchedLen
+                           : saSearcher.lce(lbRightRC, ubRightRC - 1,
+                                            matchedLen, remainingDistance);
+
+
+	      // Where we would jump if we just used the MMP
+	      auto skipMatch = mismatchIt - skipOverlap;
+	      // Where we would jump if we used the LCE
+	      auto skipLCE = revRB + lce - skipOverlap;
+
+	      auto maxSkip = std::max(skipMatch, skipLCE);
+	      revRB = maxSkip;
+	      
+	      // If NIP skipping is *enabled*, and we got to the current position
+	      // by doing an LCE query, then we allow ourselves to *double check*
+	      // by querying the last k-mer in the read.
+	      // Otherwise, we just take the skip we're given.
+	      if (!disableNIP_ and (lce > matchedLen)) {
+		if (readLen > k) {
+		  revRB = std::min(revReadEndIt - k, revRB);
+		}
+	      } 
+
+
+	      revRE = revRB + k;
+	      if (revRE == revReadEndIt) { lastSearch = true; }
+	      /*
+ 
+            // Where we would jump if we just used the MMP
+            auto skipMatch = mismatchIt - skipOverlap;
+            // Where we would jump if we used the lce
+            auto skipLCE = revRB + lce - skipOverlap;
+            // Choose the larger of the two
+            revRB = std::max(skipLCE, skipMatch);
+            if (revRB > (revReadEndIt - k)) {
+              revRB = revReadEndIt - k;
+              lastSearch = true;
+              if (disableNIP_) {
+                valid = false;
+              }
+            }
+            revRE = revRB + k;
+	      */
+          } else {
+	    /*
+            lastSearch = true;
+            revRB = revReadEndIt - k;
+            revRE = revRB + k;
+            if (disableNIP_) {
+              valid = false;
+            }
+	    */
+	    goto doneRC;
+          }
+
+        } else {
+          revRB += sampFactor;
+          revRE = revRB + k;
+        }
+      }
+    }
+  doneRC:
+
+    if (strictCheck) {
+      // The first two conditions shouldn't happen
+      // but I'm just being paranoid here
+      if (fwdHit > 0 and rcHit == 0) {
+        rcSAInts.clear();
+      } else if (rcHit > 0 and fwdHit == 0) {
+        fwdSAInts.clear();
+      } else {
+        std::sort(kmerScores.begin(), kmerScores.end());
+        auto e = std::unique(kmerScores.begin(), kmerScores.end());
+        // Compute the score for the k-mers we need to
+        // test in both the forward and rc directions.
+        int32_t fwdScore{0};
+        int32_t rcScore{0};
+        // For every kmer score structure
+        // std::cerr << "[\n";
+        for (auto kmsIt = kmerScores.begin(); kmsIt != e;
+             ++kmsIt) { //: kmerScores) {
+          auto& kms = *kmsIt;
+          // If the forward k-mer is untested, then test it
+          if (kms.fwdScore == UNTESTED) {
+            auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
+            kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
+          }
+          // accumulate the score
+          fwdScore += kms.fwdScore;
+
+          // If the rc k-mer is untested, then test it
+          if (kms.rcScore == UNTESTED) {
+            rcMer = kms.kmer.get_reverse_complement();
+            auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+            kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
+          }
+          // accumulate the score
+          rcScore += kms.rcScore;
+          // kms.print();
+          // std::cerr << "\n";
+        }
+        // std::cerr << "]\n";
+        // If the forward score is strictly greater
+        // then get rid of the rc hits.
+        if (fwdScore > rcScore) {
+          rcSAInts.clear();
+        } else if (rcScore > fwdScore) {
+          // If the rc score is strictly greater
+          // get rid of the forward hits
+          fwdSAInts.clear();
+        }
+      }
+    }
+
+    // Coverage requirements only make sense if
+    // we have disabled NIP skipping.
+    if (covReq_ > 0.0 and disableNIP_) {
+      double fwdFrac{0.0};
+      double rcFrac{0.0};
+      if (fwdSAInts.size() > 0) {
+        fwdFrac = fwdCov / static_cast<double>(readLen);
+        if (fwdFrac < covReq_) {
+          fwdSAInts.clear();
+        }
+      }
+      if (rcSAInts.size() > 0) {
+        rcFrac = rcCov / static_cast<double>(readLen);
+        if (rcFrac < covReq_) {
+          rcSAInts.clear();
+        }
+      }
+      /*
+      if (fwdFrac + rcFrac > 0.0) {
+          iomutex_.lock();
+          std::cerr << fwdFrac << ", " << rcFrac << "\n";
+          iomutex_.unlock();
+      }
+      */
+    }
+
+    auto fwdHitsStart = hits.size();
+    // If we had > 1 forward hit
+    if (fwdSAInts.size() > 1) {
+      auto processedHits = rapmap::hit_manager::intersectSAHits(
+          fwdSAInts, *rmi_, readLen, consistentHits);
+      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
+                                               hits, mateStatus);
+    } else if (fwdSAInts.size() == 1) { // only 1 hit!
+      auto& saIntervalHit = fwdSAInts.front();
+      auto initialSize = hits.size();
+      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
+        auto globalPos = SA[i];
+        auto txpID = rmi_->transcriptAtPosition(globalPos);
+        // the offset into this transcript
+        auto pos = globalPos - txpStarts[txpID];
+        int32_t hitPos = pos - saIntervalHit.queryPos;
+        hits.emplace_back(txpID, hitPos, true, readLen);
+        hits.back().mateStatus = mateStatus;
+      }
+      // Now sort by transcript ID (then position) and eliminate
+      // duplicates
+      auto sortStartIt = hits.begin() + initialSize;
+      auto sortEndIt = hits.end();
+      std::sort(sortStartIt, sortEndIt,
+                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+                  if (a.tid == b.tid) {
+                    return a.pos < b.pos;
+                  } else {
+                    return a.tid < b.tid;
+                  }
+                });
+      auto newEnd = std::unique(
+          hits.begin() + initialSize, hits.end(),
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    auto fwdHitsEnd = hits.size();
+
+    auto rcHitsStart = fwdHitsEnd;
+    // If we had > 1 rc hit
+    if (rcSAInts.size() > 1) {
+      auto processedHits = rapmap::hit_manager::intersectSAHits(
+          rcSAInts, *rmi_, readLen, consistentHits);
+      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
+                                               hits, mateStatus);
+    } else if (rcSAInts.size() == 1) { // only 1 hit!
+      auto& saIntervalHit = rcSAInts.front();
+      auto initialSize = hits.size();
+      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
+        auto globalPos = SA[i];
+        auto txpID = rmi_->transcriptAtPosition(globalPos);
+        // the offset into this transcript
+        auto pos = globalPos - txpStarts[txpID];
+        int32_t hitPos = pos - saIntervalHit.queryPos;
+        hits.emplace_back(txpID, hitPos, false, readLen);
+        hits.back().mateStatus = mateStatus;
+      }
+      // Now sort by transcript ID (then position) and eliminate
+      // duplicates
+      auto sortStartIt = hits.begin() + rcHitsStart;
+      auto sortEndIt = hits.end();
+      std::sort(sortStartIt, sortEndIt,
+                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+                  if (a.tid == b.tid) {
+                    return a.pos < b.pos;
+                  } else {
+                    return a.tid < b.tid;
+                  }
+                });
+      auto newEnd = std::unique(
+          sortStartIt, sortEndIt,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    auto rcHitsEnd = hits.size();
+
+    // If we had both forward and RC hits, then merge them
+    if ((fwdHitsEnd > fwdHitsStart) and (rcHitsEnd > rcHitsStart)) {
+      // Merge the forward and reverse hits
+      std::inplace_merge(
+          hits.begin() + fwdHitsStart, hits.begin() + fwdHitsEnd,
+          hits.begin() + rcHitsEnd,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid < b.tid;
+          });
+      // And get rid of duplicate transcript IDs
+      auto newEnd = std::unique(
+          hits.begin() + fwdHitsStart, hits.begin() + rcHitsEnd,
+          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
+            return a.tid == b.tid;
+          });
+      hits.resize(std::distance(hits.begin(), newEnd));
+    }
+    // Return true if we had any valid hits and false otherwise.
+    return foundHit;
+  }
+
+
+
+
+private:
+
+inline void getSAHits_(
+               SASearcher<RapMapIndexT>& saSearcher,
+               std::string& read,
+               std::string::iterator startIt,
+               rapmap::utils::SAInterval<OffsetT>* startInterval,
+               size_t& cov,
+               uint32_t& strandHits,
+               uint32_t& otherStrandHits,
+               std::vector<rapmap::utils::SAIntervalHit<OffsetT>>& saInts,
+               std::vector<KmerDirScore>& kmerScores,
+               bool isRC // true if read is the reverse complement, false otherwise
+               ) {
+    using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
+    auto& khash = rmi_->khash;
+    auto hashEnd = khash.end();
+    auto strictCheck = strictCheck_;
+    auto readLen = read.length();
+    auto readStartIt = read.begin();
+    auto readEndIt = read.end();
+    OffsetT matchedLen{0};
+
+    auto k = rapmap::utils::my_mer::k();
+    auto skipOverlap = 0;//k - 1;
+    OffsetT homoPolymerSkip = k / 2;
+
+    auto rb = readStartIt;
+    auto re = rb + k; 
+    OffsetT lb, ub;
+    size_t invalidPos{0};
+
+    rapmap::utils::my_mer mer, complementMer;
+    auto merIt = hashEnd;
+    auto complementMerIt = hashEnd;
+    size_t pos{0};
+    size_t sampFactor{1};
+    bool lastSearch{false};
+
+    // If we have some place to start that we have already computed
+    // then use it.
+    bool canSkipSetup{startIt > readStartIt};
+
+    if (canSkipSetup) {
+        rb = startIt;
+        invalidPos = std::distance(readStartIt, rb);
+        lb = startInterval->begin();
+        ub = startInterval->end();
+        goto skipSetup;
+    }
+
+    while (re <= readEndIt) {
+        // The distance from the beginning of the read to the
+        // start of the k-mer
+        pos = std::distance(readStartIt, rb);
+
+        //re = rb + k;
+        if (re > readEndIt) {
+          break;
+        }
+
+        // See if this k-mer would contain an N
+        // only check if we don't yet know that there are no remaining
+        // Ns
+        if (invalidPos != std::string::npos) {
+          invalidPos = read.find_first_of("nN", pos);
+        }
+
+        // If the first N is within k bases, then this k-mer is invalid
+        if (invalidPos < pos + k) {
+          // Skip to the k-mer starting at the next position
+          // (i.e. right past the N)
+          rb = read.begin() + invalidPos + 1;
+          re = rb + k;
+          // Go to the next iteration of the while loop
+          continue;
+        }
+
+        if (re <= readEndIt) {
+        // Get the k-mer and query it in the hash
+        mer = rapmap::utils::my_mer(read.c_str() + pos);
+        if (mer.is_homopolymer()) {
+          rb += homoPolymerSkip;
+          re += homoPolymerSkip;
+          continue;
+        }
+        complementMer = mer.get_reverse_complement();
+        merIt = khash.find(mer.get_bits(0, 2 * k));
+
+        // If we found the k-mer
+        if (merIt != hashEnd) {
+          if (strictCheck) {
+            ++strandHits;
+            kmerScores.emplace_back(mer, pos, ABSENT, ABSENT);
+            if (isRC) {
+                kmerScores.back().rcScore = PRESENT;
+            } else {
+                kmerScores.back().fwdScore = PRESENT;
+            }
+
+            complementMerIt = khash.find(complementMer.get_bits(0, 2 * k));
+            if (complementMerIt != hashEnd) {
+                ++otherStrandHits;
+                if (isRC) { // if we are RC, the other strand is fwd
+                    kmerScores.back().fwdScore = PRESENT;
+                } else {
+                    kmerScores.back().rcScore = PRESENT;
+                }
+            }
+          }
+        lb = merIt->second.begin();
+        ub = merIt->second.end();
+    skipSetup:
+          // lb must be 1 *less* then the current lb
+          // We can't move any further in the reverse complement direction
+          lb = std::max(static_cast<OffsetT>(0), lb - 1);
+          std::tie(lb, ub, matchedLen) =
+              saSearcher.extendSearchNaive(lb, ub, k, rb, re);
+
+          OffsetT diff = ub - lb;
+          if (ub > lb and diff < maxInterval_) {
+            uint32_t queryStart = static_cast<uint32_t>(std::distance(readStartIt, rb));
+            saInts.emplace_back(lb, ub, matchedLen, queryStart, isRC);
+
+            cov += matchedLen;
+
+            // If we didn't end the match b/c we exhausted the query
+            // test the mismatching k-mer in the other strand
+            // TODO: check for 'N'?
+            if (strictCheck_ and rb + matchedLen < readEndIt) {
+              int32_t kmerPos =
+                  static_cast<int32_t>(
+                                       std::distance(readStartIt, 
+                                       rb + matchedLen - skipOverlap));
+              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
+              // If we're on the reverse complement strand, then
+              // we have to adjust kmerPos to be with respect to the 
+              // forward strand.
+              if (isRC) {
+                  auto kp = kmerPos;
+                  kmerPos = readLen - kp - k;
+                  mer = mer.get_reverse_complement();
+              }
+              // TODO: 04/11/16
+              // Can we change this yet?
+              kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
+              if (isRC) {
+                  kmerScores.back().rcScore = ABSENT;
+              } else {
+                  kmerScores.back().fwdScore = ABSENT;
+              }
+            }
+          }
+
+          if (lastSearch) { return; }
+
+          auto mismatchIt = rb + matchedLen;
+          if (mismatchIt < readEndIt) {
+            auto remainingDistance = std::distance(mismatchIt, readEndIt);
+            auto lce = disableNIP_
+                           ? matchedLen
+                           : saSearcher.lce(lb, ub - 1,
+                                            matchedLen, remainingDistance);
+
+
+            // Where we would jump if we just used the MMP
+            auto skipMatch = mismatchIt - skipOverlap;
+            // Where we would jump if we used the LCE
+            auto skipLCE = rb + lce - skipOverlap;
+
+            auto maxSkip = std::max(skipMatch, skipLCE);
+            rb = maxSkip;
+     
+            // If NIP skipping is *enabled*, and we got to the current position
+            // by doing an LCE query, then we allow ourselves to *double check*
+            // by querying the last k-mer in the read.
+            // Otherwise, we just take the skip we're given.
+            if (!disableNIP_ and (lce > matchedLen)) {
+                if (readLen > k) {
+                    rb = std::min(readEndIt - k, rb);
+                }
+            } 
+
+
+            re = rb + k;
+            if (re == readEndIt) { lastSearch = true; }
+          } else {
+              return;
+          }
+        } else {
+          rb += sampFactor;
+          re = rb + k;
+        }
+    }
+      }
+}   
+
+  RapMapIndexT* rmi_;
+  bool disableNIP_{false};
+  double covReq_{0.0};
+  OffsetT maxInterval_;
+  bool strictCheck_;
+    std::string rcBuffer_;
+  std::mutex iomutex_;
 };
 
 #endif // SA_COLLECTOR_HPP

--- a/include/SACollector.hpp
+++ b/include/SACollector.hpp
@@ -193,8 +193,8 @@ public:
       rcMer = mer.get_reverse_complement();
 
       // See if we can find this k-mer in the hash
-      merIt = khash.find(mer.get_bits(0, 2 * k));
-      rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+      merIt = khash.find(mer.word(0));//get_bits(0, 2 * k));
+      rcMerIt = khash.find(rcMer.word(0));//rcMer.get_bits(0, 2 * k));
 
       // If we can find the k-mer in the hash
       if (merIt != hashEnd_) {
@@ -307,7 +307,7 @@ public:
             auto& kms = *kmsIt;
             // If the forward k-mer is untested, then test it
             if (kms.fwdScore == UNTESTED) {
-              auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
+              auto merIt = khash.find(kms.kmer.word(0));//get_bits(0, 2 * k));
               kms.fwdScore = (merIt != hashEnd_) ? PRESENT : ABSENT;
             }
             // accumulate the score
@@ -316,7 +316,7 @@ public:
             // If the rc k-mer is untested, then test it
             if (kms.rcScore == UNTESTED) {
               rcMer = kms.kmer.get_reverse_complement();
-              auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+              auto rcMerIt = khash.find(rcMer.word(0));//get_bits(0, 2 * k));
               kms.rcScore = (rcMerIt != hashEnd_) ? PRESENT : ABSENT;
             }
             // accumulate the score
@@ -471,8 +471,8 @@ private:
              uint32_t& strandHits, uint32_t& otherStrandHits,
              std::vector<KmerDirScore>& kmerScores
              ) {
-    IteratorT merIt;
-    IteratorT complementMerIt;
+    IteratorT merIt = hashEnd_;
+    IteratorT complementMerIt = hashEnd_;
     auto& khash = rmi_->khash;
     //auto hashEnd_ = khash.end();
     auto k = rapmap::utils::my_mer::k();
@@ -481,7 +481,7 @@ private:
 
     if (merItPtr == nullptr) {
       // We haven't tested this, so do that here
-      merIt = khash.find(mer.get_bits(0, 2 * k));
+      merIt = khash.find(mer.word(0));//get_bits(0, 2 * k));
     } else {
       // we already have this
       merIt = *merItPtr;
@@ -489,7 +489,7 @@ private:
 
     if (complementMerItPtr == nullptr) {
       // We haven't tested this, so do that here
-      complementMerIt = khash.find(complementMer.get_bits(0, 2 * k));
+      complementMerIt = khash.find(complementMer.word(0));//get_bits(0, 2 * k));
     } else {
       // we already have this
       complementMerIt = *complementMerItPtr;
@@ -635,7 +635,7 @@ private:
       // If it's not a homopolymer, then get the complement
       // k-mer and query both in the hash.
       complementMer = mer.get_reverse_complement();
-      merIt = khash.find(mer.get_bits(0, 2 * k));
+      merIt = khash.find(mer.word(0));//get_bits(0, 2 * k));
 
       // If we found the k-mer
       if (merIt != hashEnd_) {

--- a/include/SACollector.hpp
+++ b/include/SACollector.hpp
@@ -39,61 +39,64 @@ public:
 
   /** Enable NIP skipping --- default state **/
   void enableNIP() { disableNIP_ = false; }
-  
+
   /** Require a coverage fraction of at least req for all reported mappings **/
   void setCoverageRequirement(double req) { covReq_ = req; }
 
-  /** Get the current coverage requirement for mappings (0 means no requirement) **/
+  /** Get the current coverage requirement for mappings (0 means no requirement)
+   * **/
   double getCoverageRequirement() const { return covReq_; }
 
-  /** If any hit has a suffix array interval of this length or larger, just skip it **/
+  /** If any hit has a suffix array interval of this length or larger, just skip
+   * it **/
   void setMaxInterval(OffsetT maxInterval) { maxInterval_ = maxInterval; }
 
   /** Get the maximum allowable suffix array interval **/
   OffsetT getMaxInterval(OffsetT maxInterval) const { return maxInterval_; }
-  
-    bool getStrictCheck() const { return strictCheck_; };
-    void setStrictCheck(bool sc) { strictCheck_ = sc; }
-    
+
+  /** Get/Set usage of strict-checking **/
+  bool getStrictCheck() const { return strictCheck_; };
+  void setStrictCheck(bool sc) { strictCheck_ = sc; }
+
   /** Construct an SACollector given an index **/
-  SACollector(RapMapIndexT* rmi) : rmi_(rmi), maxInterval_(1000) {}
+  SACollector(RapMapIndexT* rmi) : rmi_(rmi), 
+                                   disableNIP_(false),
+                                   covReq_(0.0),
+                                   maxInterval_(1000), 
+                                   strictCheck_(false) {}
 
-    enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
-    // Record if k-mers are hits in the
-    // fwd direction, rc direction or both
-    struct KmerDirScore {
-      KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn,
-                   HitStatus fwdScoreIn, HitStatus rcScoreIn)
-          : kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn),
-            rcScore(rcScoreIn) {}
-      KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
-      bool operator==(const KmerDirScore& other) const {
-        return kpos == other.kpos;
-      }
-      bool operator<(const KmerDirScore& other) const {
-        return kpos < other.kpos;
-      }
-      void print() {
-        std::cerr << "{ " << kmer.to_str() << ", " << kpos << ", "
-                  << ((fwdScore) ? "PRESENT" : "ABSENT") << ", "
-                  << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
-      }
-      rapmap::utils::my_mer kmer;
-      int32_t kpos;
-      HitStatus fwdScore;
-      HitStatus rcScore;
-    };
+  enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
+  // Record if k-mers are hits in the
+  // fwd direction, rc direction or both
+  struct KmerDirScore {
+    KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn,
+                 HitStatus fwdScoreIn, HitStatus rcScoreIn)
+        : kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn), rcScore(rcScoreIn) {
+    }
+    KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
+    bool operator==(const KmerDirScore& other) const {
+      return kpos == other.kpos;
+    }
+    bool operator<(const KmerDirScore& other) const {
+      return kpos < other.kpos;
+    }
+    void print() {
+      std::cerr << "{ " << kmer.to_str() << ", " << kpos << ", "
+                << ((fwdScore) ? "PRESENT" : "ABSENT") << ", "
+                << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
+    }
+    rapmap::utils::my_mer kmer;
+    int32_t kpos;
+    HitStatus fwdScore;
+    HitStatus rcScore;
+  };
 
+  bool operator()(std::string& read,
+                  std::vector<rapmap::utils::QuasiAlignment>& hits,
+                  SASearcher<RapMapIndexT>& saSearcher,
+                  rapmap::utils::MateStatus mateStatus,
+                  bool consistentHits = false) {
 
-
-
-
-    bool operator()(std::string& read,
-                    std::vector<rapmap::utils::QuasiAlignment>& hits,
-                    SASearcher<RapMapIndexT>& saSearcher,
-                    rapmap::utils::MateStatus mateStatus,
-                    bool strictCheck = false, bool consistentHits = false) {
-        
     using QuasiAlignment = rapmap::utils::QuasiAlignment;
     using MateStatus = rapmap::utils::MateStatus;
 
@@ -105,15 +108,15 @@ public:
     auto salen = SA.size();
     auto hashEnd = khash.end();
     auto readLen = read.length();
-
     auto maxDist = 1.5 * readLen;
+
     auto k = rapmap::utils::my_mer::k();
     auto readStartIt = read.begin();
     auto readEndIt = read.end();
 
     auto rb = read.begin();
     auto re = rb + k;
-    
+
     uint32_t fwdHit{0};
     uint32_t rcHit{0};
 
@@ -125,6 +128,8 @@ public:
 
     rapmap::utils::my_mer mer;
     rapmap::utils::my_mer rcMer;
+
+    bool useCoverageCheck{disableNIP_ and strictCheck_};
 
     // This allows implementing our heurisic for comparing
     // forward and reverse-complement strand matches
@@ -138,33 +143,31 @@ public:
     std::vector<uint32_t> leftTxps, leftTxpsRC;
     std::vector<uint32_t> rightTxps, rightTxpsRC;
 
-    // The number of bases that a new query position (to which
-    // we skipped) should overlap the previous extension. A
-    // value of 0 means no overlap (the new search begins at the next
-    // base) while a value of (k - 1) means that k-1 bases (one less than
-    // the k-mer size) must overlap.
-
-    OffsetT skipOverlap = k-1;
-    //OffsetT skipOverlap = 0;
-
     // Number of nucleotides to skip when encountering a homopolymer k-mer.
     OffsetT homoPolymerSkip = k / 2;
     auto merIt = hashEnd;
     auto rcMerIt = hashEnd;
-
+    size_t pos{0};
+    size_t invalidPos{0};
     // Find a hit within the read
     // While we haven't fallen off the end
-    while (re < read.end()) {
+    while (re <= readEndIt) {
       // Get the k-mer at the current start position.
       // And make sure that it's valid (contains no Ns).
-      auto pos = std::distance(readStartIt, rb);
-      auto invalidPos = read.find_first_of("nN", pos);
-      if (invalidPos <= pos + k) {
-        rb = read.begin() + invalidPos + 1;
-        re = rb + k;
-        continue;
-      }
+      pos = std::distance(readStartIt, rb);
 
+      // See if this k-mer would contain an N
+      // only check if we don't yet know that there are no remaining
+      // Ns
+      if (invalidPos != std::string::npos) {
+          invalidPos = read.find_first_of("nN", pos);
+          if (invalidPos <= pos + k) {
+              rb = read.begin() + invalidPos + 1;
+              re = rb + k;
+              continue;
+          }
+      }
+      
       // If the next k-bases are valid, get the k-mer and
       // reverse complement k-mer
       mer = rapmap::utils::my_mer(read.c_str() + pos);
@@ -179,34 +182,35 @@ public:
       merIt = khash.find(mer.get_bits(0, 2 * k));
       rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
 
-      // If we can find the k-mer in the hash, get its SA interval
+      // If we can find the k-mer in the hash
       if (merIt != hashEnd) {
-          if (strictCheck) {
-            ++fwdHit;
-            // If we also match this k-mer in the rc direction
-            if (rcMerIt != hashEnd) {
-              ++rcHit;
-              kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
-            } else { // Otherwise it doesn't match in the rc direction
-              kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
-            }
-          } else { // no strict check
-            ++fwdHit;
-            if (rcMerIt != hashEnd) {
-              ++rcHit;
-            }
+        
+        if (strictCheck_) {
+          ++fwdHit;
+          // If we also match this k-mer in the rc direction
+          if (rcMerIt != hashEnd) {
+            ++rcHit;
+            kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
+          } else { // Otherwise it doesn't match in the rc direction
+            kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
+          }
+        } else { // no strict check
+          ++fwdHit;
+          if (rcMerIt != hashEnd) {
+            ++rcHit;
           }
         }
+      }
 
       // See if the reverse complement k-mer is in the hash
       if (rcMerIt != hashEnd) {
-          // The original k-mer didn't match in the foward direction
-          if (!fwdHit) {
-              ++rcHit;
-              if (strictCheck) {
-                  kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
-              }
+        // The original k-mer didn't match in the foward direction
+        if (!fwdHit) {
+          ++rcHit;
+          if (strictCheck_) {
+            kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
           }
+        }
       }
 
       // If we had a hit with either k-mer then we can
@@ -224,829 +228,105 @@ public:
     if (!foundHit) {
       return false;
     }
-
-    // If we had a hit on the forward strand
-    if (fwdHit) {
-        getSAHits_(
-                  saSearcher,
-                  read, // the read
-                  rb, // where to start the search
-                  &(merIt->second), // pointer to the search interval
-                  fwdCov,
-                  fwdHit,
-                  rcHit,
-                  fwdSAInts,
-                  kmerScores,
-                  false);
-    }
-
-    if (rcHit >= fwdHit) {
-        rapmap::utils::reverseRead(read, rcBuffer_);
-        getSAHits_(
-                  saSearcher,
-                  rcBuffer_, // the read
-                  rcBuffer_.begin(), // where to start the search
-                  nullptr, // pointer to the search interval
-                  rcCov,
-                  rcHit,
-                  fwdHit,
-                  rcSAInts,
-                  kmerScores,
-                  true);
-    }
-
-    if (strictCheck) {
-      // The first two conditions shouldn't happen
-      // but I'm just being paranoid here
-      if (fwdHit > 0 and rcHit == 0) {
-        rcSAInts.clear();
-      } else if (rcHit > 0 and fwdHit == 0) {
-        fwdSAInts.clear();
-      } else {
-        std::sort(kmerScores.begin(), kmerScores.end());
-        auto e = std::unique(kmerScores.begin(), kmerScores.end());
-        // Compute the score for the k-mers we need to
-        // test in both the forward and rc directions.
-        int32_t fwdScore{0};
-        int32_t rcScore{0};
-        // For every kmer score structure
-        // std::cerr << "[\n";
-        for (auto kmsIt = kmerScores.begin(); kmsIt != e;
-             ++kmsIt) { //: kmerScores) {
-          auto& kms = *kmsIt;
-          // If the forward k-mer is untested, then test it
-          if (kms.fwdScore == UNTESTED) {
-            auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
-            kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
-          }
-          // accumulate the score
-          fwdScore += kms.fwdScore;
-
-          // If the rc k-mer is untested, then test it
-          if (kms.rcScore == UNTESTED) {
-            rcMer = kms.kmer.get_reverse_complement();
-            auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
-            kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
-          }
-          // accumulate the score
-          rcScore += kms.rcScore;
-          // kms.print();
-          // std::cerr << "\n";
-        }
-        // std::cerr << "]\n";
-        // If the forward score is strictly greater
-        // then get rid of the rc hits.
-        if (fwdScore > rcScore) {
-          rcSAInts.clear();
-        } else if (rcScore > fwdScore) {
-          // If the rc score is strictly greater
-          // get rid of the forward hits
-          fwdSAInts.clear();
-        }
-      }
-    }
-
-    // Coverage requirements only make sense if
-    // we have disabled NIP skipping.
-    if (covReq_ > 0.0 and disableNIP_) {
-      double fwdFrac{0.0};
-      double rcFrac{0.0};
-      if (fwdSAInts.size() > 0) {
-        fwdFrac = fwdCov / static_cast<double>(readLen);
-        if (fwdFrac < covReq_) {
-          fwdSAInts.clear();
-        }
-      }
-      if (rcSAInts.size() > 0) {
-        rcFrac = rcCov / static_cast<double>(readLen);
-        if (rcFrac < covReq_) {
-          rcSAInts.clear();
-        }
-      }
-      /*
-      if (fwdFrac + rcFrac > 0.0) {
-          iomutex_.lock();
-          std::cerr << fwdFrac << ", " << rcFrac << "\n";
-          iomutex_.unlock();
-      }
-      */
-    }
-
-    auto fwdHitsStart = hits.size();
-    // If we had > 1 forward hit
-    if (fwdSAInts.size() > 1) {
-      auto processedHits = rapmap::hit_manager::intersectSAHits(
-          fwdSAInts, *rmi_, readLen, consistentHits);
-      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
-                                               hits, mateStatus);
-    } else if (fwdSAInts.size() == 1) { // only 1 hit!
-      auto& saIntervalHit = fwdSAInts.front();
-      auto initialSize = hits.size();
-      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
-        auto globalPos = SA[i];
-        auto txpID = rmi_->transcriptAtPosition(globalPos);
-        // the offset into this transcript
-        auto pos = globalPos - txpStarts[txpID];
-        int32_t hitPos = pos - saIntervalHit.queryPos;
-        hits.emplace_back(txpID, hitPos, true, readLen);
-        hits.back().mateStatus = mateStatus;
-      }
-      // Now sort by transcript ID (then position) and eliminate
-      // duplicates
-      auto sortStartIt = hits.begin() + initialSize;
-      auto sortEndIt = hits.end();
-      std::sort(sortStartIt, sortEndIt,
-                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                  if (a.tid == b.tid) {
-                    return a.pos < b.pos;
-                  } else {
-                    return a.tid < b.tid;
-                  }
-                });
-      auto newEnd = std::unique(
-          hits.begin() + initialSize, hits.end(),
-          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-            return a.tid == b.tid;
-          });
-      hits.resize(std::distance(hits.begin(), newEnd));
-    }
-    auto fwdHitsEnd = hits.size();
-
-    auto rcHitsStart = fwdHitsEnd;
-    // If we had > 1 rc hit
-    if (rcSAInts.size() > 1) {
-      auto processedHits = rapmap::hit_manager::intersectSAHits(
-          rcSAInts, *rmi_, readLen, consistentHits);
-      rapmap::hit_manager::collectHitsSimpleSA(processedHits, readLen, maxDist,
-                                               hits, mateStatus);
-    } else if (rcSAInts.size() == 1) { // only 1 hit!
-      auto& saIntervalHit = rcSAInts.front();
-      auto initialSize = hits.size();
-      for (OffsetT i = saIntervalHit.begin; i != saIntervalHit.end; ++i) {
-        auto globalPos = SA[i];
-        auto txpID = rmi_->transcriptAtPosition(globalPos);
-        // the offset into this transcript
-        auto pos = globalPos - txpStarts[txpID];
-        int32_t hitPos = pos - saIntervalHit.queryPos;
-        hits.emplace_back(txpID, hitPos, false, readLen);
-        hits.back().mateStatus = mateStatus;
-      }
-      // Now sort by transcript ID (then position) and eliminate
-      // duplicates
-      auto sortStartIt = hits.begin() + rcHitsStart;
-      auto sortEndIt = hits.end();
-      std::sort(sortStartIt, sortEndIt,
-                [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-                  if (a.tid == b.tid) {
-                    return a.pos < b.pos;
-                  } else {
-                    return a.tid < b.tid;
-                  }
-                });
-      auto newEnd = std::unique(
-          sortStartIt, sortEndIt,
-          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-            return a.tid == b.tid;
-          });
-      hits.resize(std::distance(hits.begin(), newEnd));
-    }
-    auto rcHitsEnd = hits.size();
-
-    // If we had both forward and RC hits, then merge them
-    if ((fwdHitsEnd > fwdHitsStart) and (rcHitsEnd > rcHitsStart)) {
-      // Merge the forward and reverse hits
-      std::inplace_merge(
-          hits.begin() + fwdHitsStart, hits.begin() + fwdHitsEnd,
-          hits.begin() + rcHitsEnd,
-          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-            return a.tid < b.tid;
-          });
-      // And get rid of duplicate transcript IDs
-      auto newEnd = std::unique(
-          hits.begin() + fwdHitsStart, hits.begin() + rcHitsEnd,
-          [](const QuasiAlignment& a, const QuasiAlignment& b) -> bool {
-            return a.tid == b.tid;
-          });
-      hits.resize(std::distance(hits.begin(), newEnd));
-    }
-    // Return true if we had any valid hits and false otherwise.
-    return foundHit;
-    }
-
-  /** Find the mappings for a read **/
-  bool oldOperator(std::string& read,
-                  std::vector<rapmap::utils::QuasiAlignment>& hits,
-                  SASearcher<RapMapIndexT>& saSearcher,
-                  rapmap::utils::MateStatus mateStatus,
-                  bool strictCheck = false, bool consistentHits = false) {
-
-    using QuasiAlignment = rapmap::utils::QuasiAlignment;
-    using MateStatus = rapmap::utils::MateStatus;
-
-    auto& rankDict = rmi_->rankDict;
-    auto& txpStarts = rmi_->txpOffsets;
-    auto& SA = rmi_->SA;
-    auto& khash = rmi_->khash;
-    auto& text = rmi_->seq;
-    uint32_t sampFactor{1};
-    auto salen = SA.size();
-    auto hashEnd = khash.end();
-
-    auto readLen = read.length();
-    auto maxDist = 1.5 * readLen;
-    auto k = rapmap::utils::my_mer::k();
-    auto readStartIt = read.begin();
-    auto readEndIt = read.end();
-
-    auto readRevStartIt = read.rbegin();
-    auto readRevEndIt = read.rend();
-
-    auto rb = read.begin();
-    auto re = rb + k;
-    // Were the last "rightmost" hit ended on the query
-    auto prevHitTail = read.begin();
     
-    OffsetT lbLeftFwd = 0, ubLeftFwd = 0;
-    OffsetT lbLeftRC = 0, ubLeftRC = 0;
-    OffsetT lbRightFwd = 0, ubRightFwd = 0;
-    OffsetT lbRightRC = 0, ubRightRC = 0;
-    OffsetT matchedLen;
-
-    uint32_t fwdHit{0};
-    uint32_t rcHit{0};
-
-    size_t fwdCov{0};
-    size_t rcCov{0};
-    bool foundHit = false;
-    bool isRev = false;
-    rapmap::utils::my_mer mer;
-    rapmap::utils::my_mer rcMer;
-
-    enum HitStatus { ABSENT = -1, UNTESTED = 0, PRESENT = 1 };
-    // Record if k-mers are hits in the
-    // fwd direction, rc direction or both
-    struct KmerDirScore {
-      KmerDirScore(rapmap::utils::my_mer kmerIn, int32_t kposIn,
-                   HitStatus fwdScoreIn, HitStatus rcScoreIn)
-          : kmer(kmerIn), kpos(kposIn), fwdScore(fwdScoreIn),
-            rcScore(rcScoreIn) {}
-      KmerDirScore() : kpos(0), fwdScore(UNTESTED), rcScore(UNTESTED) {}
-      bool operator==(const KmerDirScore& other) const {
-        return kpos == other.kpos;
-      }
-      bool operator<(const KmerDirScore& other) const {
-        return kpos < other.kpos;
-      }
-      void print() {
-        std::cerr << "{ " << kmer.to_str() << ", " << kpos << ", "
-                  << ((fwdScore) ? "PRESENT" : "ABSENT") << ", "
-                  << ((rcScore) ? "PRESENT" : "ABSENT") << "}\t";
-      }
-      rapmap::utils::my_mer kmer;
-      int32_t kpos;
-      HitStatus fwdScore;
-      HitStatus rcScore;
-    };
-
-    // This allows implementing our heurisic for comparing
-    // forward and reverse-complement strand matches
-    std::vector<KmerDirScore> kmerScores;
-
-    using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
-
-    std::vector<SAIntervalHit> fwdSAInts;
-    std::vector<SAIntervalHit> rcSAInts;
-
-    std::vector<uint32_t> leftTxps, leftTxpsRC;
-    std::vector<uint32_t> rightTxps, rightTxpsRC;
-
-    // The number of bases that a new query position (to which
-    // we skipped) should overlap the previous extension. A
-    // value of 0 means no overlap (the new search begins at the next
-    // base) while a value of (k - 1) means that k-1 bases (one less than
-    // the k-mer size) must overlap.
-
-    OffsetT skipOverlap = k-1;
-    //OffsetT skipOverlap = 0;
-
-    // Number of nucleotides to skip when encountering a homopolymer k-mer.
-    OffsetT homoPolymerSkip = k / 2;
-
-    // Find a hit within the read
-    // While we haven't fallen off the end
-    while (re < read.end()) {
-
-      // Get the k-mer at the current start position.
-      // And make sure that it's valid (contains no Ns).
-      auto pos = std::distance(readStartIt, rb);
-      auto invalidPos = read.find_first_of("nN", pos);
-      if (invalidPos <= pos + k) {
-        rb = read.begin() + invalidPos + 1;
-        re = rb + k;
-        continue;
-      }
-
-      // If the next k-bases are valid, get the k-mer and
-      // reverse complement k-mer
-      mer = rapmap::utils::my_mer(read.c_str() + pos);
-      if (mer.is_homopolymer()) {
-        rb += homoPolymerSkip;
-        re += homoPolymerSkip;
-        continue;
-      }
-      rcMer = mer.get_reverse_complement();
-
-      // See if we can find this k-mer in the hash
-      auto merIt = khash.find(mer.get_bits(0, 2 * k));
-      auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
-
-      // If we can find the k-mer in the hash, get its SA interval
-      if (merIt != hashEnd) {
-        OffsetT lb = merIt->second.begin();
-        OffsetT ub = merIt->second.end();
-
-        // lb must be 1 *less* then the current lb
-        auto lbRestart = std::max(static_cast<OffsetT>(0), lb - 1);
-
-        // Extend the SA interval using the read sequence as far as
-        // possible
-        std::tie(lbLeftFwd, ubLeftFwd, matchedLen) =
-            saSearcher.extendSearchNaive(lbRestart, ub, k, rb, readEndIt);
-
-        // If the SA interval is valid, and not too wide, then record
-        // the hit.
-        OffsetT diff = ubLeftFwd - lbLeftFwd;
-        if (ubLeftFwd > lbLeftFwd and diff < maxInterval_) {
-          auto queryStart = std::distance(read.begin(), rb);
-          fwdSAInts.emplace_back(lbLeftFwd, ubLeftFwd, matchedLen, queryStart,
-                                 false);
-          // iomutex_.lock();
-          // std::cerr << "matchedLen = " << matchedLen << " (qp = " <<
-          // queryStart << ")\n";
-          // iomutex_.unlock();
-          fwdCov += matchedLen;
-          if (strictCheck) {
-            ++fwdHit;
-            // If we also match this k-mer in the rc direction
-            if (rcMerIt != hashEnd) {
-              ++rcHit;
-              kmerScores.emplace_back(mer, pos, PRESENT, PRESENT);
-            } else { // Otherwise it doesn't match in the rc direction
-              kmerScores.emplace_back(mer, pos, PRESENT, ABSENT);
-            }
-
-            // If we didn't end the match b/c we exhausted the query
-            // test the mismatching k-mer in the other strand
-            // TODO: check for 'N'?
-            if (rb + matchedLen < readEndIt) {
-              auto kmerPos =
-                  std::distance(readStartIt, rb + matchedLen - skipOverlap);
-              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-              kmerScores.emplace_back(mer, kmerPos, ABSENT, UNTESTED);
-            }
-          } else { // no strict check
-            ++fwdHit;
-            if (rcMerIt != hashEnd) {
-              ++rcHit;
-            }
-          }
-        }
-      }
-
-      // See if the reverse complement k-mer is in the hash
-      if (rcMerIt != hashEnd) {
-        lbLeftRC = rcMerIt->second.begin();
-        ubLeftRC = rcMerIt->second.end();
-        OffsetT diff = ubLeftRC - lbLeftRC;
-        if (ubLeftRC > lbLeftRC) {
-          // The original k-mer didn't match in the foward direction
-          if (!fwdHit) {
-            ++rcHit;
-            if (strictCheck) {
-              kmerScores.emplace_back(mer, pos, ABSENT, PRESENT);
-            }
-          }
-        }
-      }
-
-      // If we had a hit with either k-mer then we can
-      // break out of this loop to look for the next informative position
-      if (fwdHit + rcHit > 0) {
-        foundHit = true;
-        break;
-      }
-      ++rb;
-      ++re;
-    }
-
-    // If we went the entire length of the read without finding a hit
-    // then we can bail.
-    if (!foundHit) {
-      return false;
-    }
-
-    bool lastSearch{false};
+    bool didCheckFwd{false};
     // If we had a hit on the forward strand
     if (fwdHit) {
-
-      // The length of this match
-      auto matchLen = fwdSAInts.front().len;
-      // The iterator to where this match began
-      rb = read.begin() + fwdSAInts.front().queryPos;
-
-      // How much of the sequence is left after the
-      // end of our match.
-      auto remainingLength = std::distance(rb + matchLen, readEndIt);
-
-      // We haven't done LCE yet, so any match here is "verified".
-      // If we're fewer than k bases from the end, don't bother to
-      // do any more work in this branch.
-      if (remainingLength < k) { goto doneFwd; }
-      
-      // [lb, ub) is the suffix array interval for the MMP (maximum mappable
-      // prefix) of the k-mer we found.  The NIP (next informative position)
-      // in the sequence is the position after
-      // the LCE (longest common extension) of T[SA[lb]:] and T[SA[ub-1]:]
-
-      // If NIP skipping is disabled, then just treat the NIP as the MMP.
-      auto lce = disableNIP_ ? matchLen
-                             : saSearcher.lce(lbLeftFwd, ubLeftFwd - 1,
-                                              matchLen, remainingLength);
-
-      auto fwdSkip = std::max(static_cast<OffsetT>(matchLen) - skipOverlap,
-                              static_cast<OffsetT>(lce) - skipOverlap);
-
-      // The maximum position at which we could start our next search.
-      size_t maxPos = static_cast<OffsetT>(std::distance(readStartIt, rb) + fwdSkip);
-      size_t nextInformativePosition = maxPos;
-
-      
-      // If NIP skipping is *enabled*, and we got to the current position
-      // by doing an LCE query, then we allow ourselves to *double check*
-      // by querying the last k-mer in the read.
-      // Otherwise, we just take the skip we're given.
-      OffsetT nipSkip;
-      if (!disableNIP_ and (lce > matchLen)) {
-	size_t lastKmerPos = std::max(static_cast<OffsetT>(0),
-				    static_cast<OffsetT>(readLen) - static_cast<OffsetT>(k));
-	nextInformativePosition = std::min(lastKmerPos, nextInformativePosition);
-      } 
-
-      /*
-      auto nipSkip = disableNIP_ ? static_cast<OffsetT>(readLen)
-                                 : std::max(static_cast<OffsetT>(0),
-                                            static_cast<OffsetT>(readLen) -
-                                                static_cast<OffsetT>(k));
-      size_t nextInformativePosition = std::min(
-          nipSkip,
-          static_cast<OffsetT>(std::distance(readStartIt, rb) + fwdSkip));
-      */
-      
-      rb = read.begin() + nextInformativePosition;
-      re = rb + k;
-
-      size_t invalidPos{0};
-      while (re <= readEndIt) {
-        // The offset into the string
-        auto pos = std::distance(readStartIt, rb);
-
-        // The position of the first N in the k-mer (if there is one)
-        // If we have already verified there are no Ns in the remainder
-        // of the string (invalidPos is std::string::npos) then we can
-        // skip this test.
-        if (invalidPos != std::string::npos) {
-          invalidPos = read.find_first_of("nN", pos);
-        }
-
-        // If the first N is within k bases, then this k-mer is invalid
-        if (invalidPos < pos + k) {
-          // A valid k-mer can't start until after the 'N'
-          nextInformativePosition = invalidPos + 1;
-          rb = read.begin() + nextInformativePosition;
-          re = rb + k;
-          // Go to the next iteration of the while loop
-          continue;
-        }
-
-        // If the current end position is valid
-        if (re <= readEndIt) {
-
-          mer = rapmap::utils::my_mer(read.c_str() + pos);
-          if (mer.is_homopolymer()) {
-            rb += homoPolymerSkip;
-            re = rb + k;
-            continue;
-          }
-          auto merIt = khash.find(mer.get_bits(0, 2 * k));
-
-          if (merIt != hashEnd) {
-            if (strictCheck) {
-              ++fwdHit;
-              kmerScores.emplace_back(mer, pos, PRESENT, UNTESTED);
-              auto rcMer = mer.get_reverse_complement();
-              auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
-              if (rcMerIt != hashEnd) {
-                ++rcHit;
-                kmerScores.back().rcScore = PRESENT;
-              }
-            }
-
-            lbRightFwd = merIt->second.begin();
-            ubRightFwd = merIt->second.end();
-
-            // lb must be 1 *less* then the current lb
-            lbRightFwd = std::max(static_cast<OffsetT>(0), lbRightFwd - 1);
-            std::tie(lbRightFwd, ubRightFwd, matchedLen) =
-                saSearcher.extendSearchNaive(lbRightFwd, ubRightFwd, k, rb,
-                                             readEndIt);
-
-            OffsetT diff = ubRightFwd - lbRightFwd;
-            if (ubRightFwd > lbRightFwd and diff < maxInterval_) {
-              auto queryStart = std::distance(read.begin(), rb);
-              fwdSAInts.emplace_back(lbRightFwd, ubRightFwd, matchedLen,
-                                     queryStart, false);
-              // iomutex_.lock();
-              // std::cerr << "matchedLen = " << matchedLen << " (qp = " <<
-              // queryStart << ")\n";
-              // iomutex_.unlock();
-              fwdCov += matchedLen;
-              // If we didn't end the match b/c we exhausted the query
-              // test the mismatching k-mer in the other strand
-              // TODO: check for 'N'?
-              if (strictCheck and rb + matchedLen < readEndIt) {
-                auto kmerPos =
-                    std::distance(readStartIt, rb + matchedLen - skipOverlap);
-                mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-                // TODO: 04/11/16
-                kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
-              }
-            }
-
-            if (lastSearch) {
-              break;
-            }
-            auto mismatchIt = rb + matchedLen;
-            if (mismatchIt < readEndIt) {
-              auto remainingDistance = std::distance(mismatchIt, readEndIt);
-              auto lce = disableNIP_
-                             ? matchedLen
-                             : saSearcher.lce(lbRightFwd, ubRightFwd - 1,
-                                              matchedLen, remainingDistance);
-
-	      // Where we would jump if we just used the MMP
-	      auto skipMatch = mismatchIt - skipOverlap;
-	      // Where we would jump if we used the LCE
-	      auto skipLCE = rb + lce - skipOverlap;
-
-	      auto maxSkip = std::max(skipMatch, skipLCE);
-	      rb = maxSkip;
-	      
-	      // If NIP skipping is *enabled*, and we got to the current position
-	      // by doing an LCE query, then we allow ourselves to *double check*
-	      // by querying the last k-mer in the read.
-	      // Otherwise, we just take the skip we're given.
-	      if (!disableNIP_ and (lce > matchLen)) {
-		if (readLen > k) {
-		  rb = std::min(readEndIt - k, rb);
-		}
-	      } 
-	      /* 
-              if (rb > (readEndIt - k)) {
-                rb = readEndIt - k;
-                lastSearch = true;
-                if (disableNIP_) {
-                  valid = false;
-                }
-              }
-	      */
-              re = rb + k;
-	      if (re == readEndIt) { lastSearch = true; }
-
-            } else {
-	      /*
-              lastSearch = true;
-              rb = readEndIt - k;
-              re = rb + k;
-              if (disableNIP_) {
-                valid = false;
-              }
-	      */
-	      goto doneFwd;
-            }
-
-          } else {
-            rb += sampFactor;
-            re = rb + k;
-          }
-        }
-      }
+        didCheckFwd = true;
+      getSAHits_(saSearcher,
+                 read,             // the read
+                 rb,               // where to start the search
+                 &(merIt->second), // pointer to the search interval
+                 fwdCov, fwdHit, rcHit, fwdSAInts, kmerScores, false);
     }
-  doneFwd:
 
-    lastSearch = false;
-    if (rcHit >= fwdHit) {
-      size_t pos{read.length() - k};
+    // Good enough?
+    //bool checkRC = (rcHit >= fwdHit);
+    // otherwise use this one
+    bool checkRC = useCoverageCheck ? (rcHit > 0) : (rcHit >= fwdHit);
 
-      auto revReadEndIt = read.rend();
-
-      auto revRB = read.rbegin();
-      auto revRE = revRB + k;
-
-      auto invalidPosIt = revRB;
-      while (revRE <= revReadEndIt) {
-
-        revRE = revRB + k;
-        if (revRE > revReadEndIt) {
-          break;
-        }
-
-        // See if this k-mer would contain an N
-        // only check if we don't yet know that there are no remaining
-        // Ns
-        if (invalidPosIt != revReadEndIt) {
-          invalidPosIt = std::find_if(revRB, revRE, [](const char c) -> bool {
-            return c == 'n' or c == 'N';
-          });
-        }
-
-        // If we found an N before the end of the k-mer
-        if (invalidPosIt < revRE) {
-          // Skip to the k-mer starting at the next position
-          // (i.e. right past the N)
-          revRB = invalidPosIt + 1;
-          continue;
-        }
-
-        // The distance from the beginning of the read to the
-        // start of the k-mer
-        pos = std::distance(revRE, revReadEndIt);
-
-        // Get the k-mer and query it in the hash
-        mer = rapmap::utils::my_mer(read.c_str() + pos);
-        if (mer.is_homopolymer()) {
-          revRB += homoPolymerSkip;
-          revRE += homoPolymerSkip;
-          continue;
-        }
-        rcMer = mer.get_reverse_complement();
-        auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
-
-        // If we found the k-mer
-        if (rcMerIt != hashEnd) {
-          if (strictCheck) {
-            ++rcHit;
-            kmerScores.emplace_back(mer, pos, UNTESTED, PRESENT);
-            auto merIt = khash.find(mer.get_bits(0, 2 * k));
-            if (merIt != hashEnd) {
-              ++fwdHit;
-              kmerScores.back().fwdScore = PRESENT;
-            }
-          }
-
-          lbRightRC = rcMerIt->second.begin();
-          ubRightRC = rcMerIt->second.end();
-
-          // lb must be 1 *less* then the current lb
-          // We can't move any further in the reverse complement direction
-          lbRightRC = std::max(static_cast<OffsetT>(0), lbRightRC - 1);
-          std::tie(lbRightRC, ubRightRC, matchedLen) =
-              saSearcher.extendSearchNaive(lbRightRC, ubRightRC, k, revRB,
-                                           revReadEndIt, true);
-
-          OffsetT diff = ubRightRC - lbRightRC;
-          if (ubRightRC > lbRightRC and diff < maxInterval_) {
-            auto queryStart = std::distance(read.rbegin(), revRB);
-            rcSAInts.emplace_back(lbRightRC, ubRightRC, matchedLen, queryStart,
-                                  true);
-            rcCov += matchedLen;
-            // If we didn't end the match b/c we exhausted the query
-            // test the mismatching k-mer in the other strand
-            // TODO: check for 'N'?
-            if (strictCheck and revRB + matchedLen < revReadEndIt) {
-              auto kmerPos = std::distance(revRB + matchedLen, revReadEndIt);
-              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-              // TODO: 04/11/16
-              kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
-            }
-          }
-
-          if (lastSearch) {
-            break;
-          }
-          auto mismatchIt = revRB + matchedLen;
-          if (mismatchIt < revReadEndIt) {
-            auto remainingDistance = std::distance(mismatchIt, revReadEndIt);
-            auto lce = disableNIP_
-                           ? matchedLen
-                           : saSearcher.lce(lbRightRC, ubRightRC - 1,
-                                            matchedLen, remainingDistance);
-
-
-	      // Where we would jump if we just used the MMP
-	      auto skipMatch = mismatchIt - skipOverlap;
-	      // Where we would jump if we used the LCE
-	      auto skipLCE = revRB + lce - skipOverlap;
-
-	      auto maxSkip = std::max(skipMatch, skipLCE);
-	      revRB = maxSkip;
-	      
-	      // If NIP skipping is *enabled*, and we got to the current position
-	      // by doing an LCE query, then we allow ourselves to *double check*
-	      // by querying the last k-mer in the read.
-	      // Otherwise, we just take the skip we're given.
-	      if (!disableNIP_ and (lce > matchedLen)) {
-		if (readLen > k) {
-		  revRB = std::min(revReadEndIt - k, revRB);
-		}
-	      } 
-
-
-	      revRE = revRB + k;
-	      if (revRE == revReadEndIt) { lastSearch = true; }
-	      /*
- 
-            // Where we would jump if we just used the MMP
-            auto skipMatch = mismatchIt - skipOverlap;
-            // Where we would jump if we used the lce
-            auto skipLCE = revRB + lce - skipOverlap;
-            // Choose the larger of the two
-            revRB = std::max(skipLCE, skipMatch);
-            if (revRB > (revReadEndIt - k)) {
-              revRB = revReadEndIt - k;
-              lastSearch = true;
-              if (disableNIP_) {
-                valid = false;
-              }
-            }
-            revRE = revRB + k;
-	      */
-          } else {
-	    /*
-            lastSearch = true;
-            revRB = revReadEndIt - k;
-            revRE = revRB + k;
-            if (disableNIP_) {
-              valid = false;
-            }
-	    */
-	    goto doneRC;
-          }
-
-        } else {
-          revRB += sampFactor;
-          revRE = revRB + k;
-        }
-      }
+    // If we had a hit on the reverse complement strand
+    if (checkRC) {
+      rapmap::utils::reverseRead(read, rcBuffer_);
+      getSAHits_(saSearcher,
+                 rcBuffer_,         // the read
+                 rcBuffer_.begin(), // where to start the search
+                 nullptr,           // pointer to the search interval
+                 rcCov, rcHit, fwdHit, rcSAInts, kmerScores, true);
     }
-  doneRC:
+    
+    // Now, if we *didn't* check the forward strand at first, but we encountered fwd hits 
+    // while looking at the RC strand, then check the fwd strand now
+    
+    // Good enough?
+    //bool checkFwd = (fwdHit >= rcHit);
+    // otherwise use this one
+    bool checkFwd = useCoverageCheck ? (fwdHit > 0) : (fwdHit >= rcHit);
+    if (!didCheckFwd and checkFwd) {
+        didCheckFwd = true;
+      getSAHits_(saSearcher,
+                 read,             // the read
+                 read.begin(),               // where to start the search
+                 nullptr, // pointer to the search interval
+                 fwdCov, fwdHit, rcHit, fwdSAInts, kmerScores, false);
+    }
 
-    if (strictCheck) {
-      // The first two conditions shouldn't happen
-      // but I'm just being paranoid here
-      if (fwdHit > 0 and rcHit == 0) {
-        rcSAInts.clear();
-      } else if (rcHit > 0 and fwdHit == 0) {
-        fwdSAInts.clear();
-      } else {
-        std::sort(kmerScores.begin(), kmerScores.end());
-        auto e = std::unique(kmerScores.begin(), kmerScores.end());
-        // Compute the score for the k-mers we need to
-        // test in both the forward and rc directions.
-        int32_t fwdScore{0};
-        int32_t rcScore{0};
-        // For every kmer score structure
-        // std::cerr << "[\n";
-        for (auto kmsIt = kmerScores.begin(); kmsIt != e;
-             ++kmsIt) { //: kmerScores) {
-          auto& kms = *kmsIt;
-          // If the forward k-mer is untested, then test it
-          if (kms.fwdScore == UNTESTED) {
-            auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
-            kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
-          }
-          // accumulate the score
-          fwdScore += kms.fwdScore;
-
-          // If the rc k-mer is untested, then test it
-          if (kms.rcScore == UNTESTED) {
-            rcMer = kms.kmer.get_reverse_complement();
-            auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
-            kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
-          }
-          // accumulate the score
-          rcScore += kms.rcScore;
-          // kms.print();
-          // std::cerr << "\n";
-        }
-        // std::cerr << "]\n";
-        // If the forward score is strictly greater
-        // then get rid of the rc hits.
-        if (fwdScore > rcScore) {
+    if (strictCheck_) {
+      // If we're computing coverage, then we can make use of that info here
+      if (useCoverageCheck) {
+        if (fwdCov > rcCov) {
           rcSAInts.clear();
-        } else if (rcScore > fwdScore) {
-          // If the rc score is strictly greater
-          // get rid of the forward hits
+        } else if (rcCov > fwdCov) {
           fwdSAInts.clear();
+        }
+      } else { // use the k-mer "spot check"
+        // The first two conditions shouldn't happen
+        // but I'm just being paranoid here
+        if (fwdHit > 0 and rcHit == 0) {
+          rcSAInts.clear();
+        } else if (rcHit > 0 and fwdHit == 0) {
+          fwdSAInts.clear();
+        } else {
+          std::sort(kmerScores.begin(), kmerScores.end());
+          auto e = std::unique(kmerScores.begin(), kmerScores.end());
+          // Compute the score for the k-mers we need to
+          // test in both the forward and rc directions.
+          int32_t fwdScore{0};
+          int32_t rcScore{0};
+          // For every kmer score structure
+          // std::cerr << "[\n";
+          for (auto kmsIt = kmerScores.begin(); kmsIt != e;
+               ++kmsIt) { //: kmerScores) {
+            auto& kms = *kmsIt;
+            // If the forward k-mer is untested, then test it
+            if (kms.fwdScore == UNTESTED) {
+              auto merIt = khash.find(kms.kmer.get_bits(0, 2 * k));
+              kms.fwdScore = (merIt != hashEnd) ? PRESENT : ABSENT;
+            }
+            // accumulate the score
+            fwdScore += kms.fwdScore;
+
+            // If the rc k-mer is untested, then test it
+            if (kms.rcScore == UNTESTED) {
+              rcMer = kms.kmer.get_reverse_complement();
+              auto rcMerIt = khash.find(rcMer.get_bits(0, 2 * k));
+              kms.rcScore = (rcMerIt != hashEnd) ? PRESENT : ABSENT;
+            }
+            // accumulate the score
+            rcScore += kms.rcScore;
+            // kms.print();
+            // std::cerr << "\n";
+          }
+          // std::cerr << "]\n";
+          // If the forward score is strictly greater
+          // then get rid of the rc hits.
+          if (fwdScore > rcScore) {
+            rcSAInts.clear();
+          } else if (rcScore > fwdScore) {
+            // If the rc score is strictly greater
+            // get rid of the forward hits
+            fwdSAInts.clear();
+          }
         }
       }
     }
@@ -1068,13 +348,6 @@ public:
           rcSAInts.clear();
         }
       }
-      /*
-      if (fwdFrac + rcFrac > 0.0) {
-          iomutex_.lock();
-          std::cerr << fwdFrac << ", " << rcFrac << "\n";
-          iomutex_.unlock();
-      }
-      */
     }
 
     auto fwdHitsStart = hits.size();
@@ -1178,38 +451,32 @@ public:
     return foundHit;
   }
 
-
-
-
 private:
-
-inline void getSAHits_(
-               SASearcher<RapMapIndexT>& saSearcher,
-               std::string& read,
-               std::string::iterator startIt,
-               rapmap::utils::SAInterval<OffsetT>* startInterval,
-               size_t& cov,
-               uint32_t& strandHits,
-               uint32_t& otherStrandHits,
-               std::vector<rapmap::utils::SAIntervalHit<OffsetT>>& saInts,
-               std::vector<KmerDirScore>& kmerScores,
-               bool isRC // true if read is the reverse complement, false otherwise
-               ) {
+  inline void getSAHits_(
+      SASearcher<RapMapIndexT>& saSearcher, std::string& read,
+      std::string::iterator startIt,
+      rapmap::utils::SAInterval<OffsetT>* startInterval, size_t& cov,
+      uint32_t& strandHits, uint32_t& otherStrandHits,
+      std::vector<rapmap::utils::SAIntervalHit<OffsetT>>& saInts,
+      std::vector<KmerDirScore>& kmerScores,
+      bool isRC // true if read is the reverse complement, false otherwise
+      ) {
     using SAIntervalHit = rapmap::utils::SAIntervalHit<OffsetT>;
     auto& khash = rmi_->khash;
+
     auto hashEnd = khash.end();
-    auto strictCheck = strictCheck_;
     auto readLen = read.length();
     auto readStartIt = read.begin();
     auto readEndIt = read.end();
     OffsetT matchedLen{0};
 
     auto k = rapmap::utils::my_mer::k();
-    auto skipOverlap = 0;//k - 1;
+    auto skipOverlapMMP = k - 1; 
+    auto skipOverlapNIP = k - 1;
     OffsetT homoPolymerSkip = k / 2;
 
     auto rb = readStartIt;
-    auto re = rb + k; 
+    auto re = rb + k;
     OffsetT lb, ub;
     size_t invalidPos{0};
 
@@ -1219,172 +486,229 @@ inline void getSAHits_(
     size_t pos{0};
     size_t sampFactor{1};
     bool lastSearch{false};
+    size_t prevMMPEnd{0};
 
     // If we have some place to start that we have already computed
     // then use it.
-    bool canSkipSetup{startIt > readStartIt};
+    bool canSkipSetup{startInterval != nullptr};
 
     if (canSkipSetup) {
-        rb = startIt;
-        invalidPos = std::distance(readStartIt, rb);
-        lb = startInterval->begin();
-        ub = startInterval->end();
-        goto skipSetup;
+      rb = startIt;
+      re = rb + k;
+      pos = std::distance(readStartIt, rb);
+      invalidPos = pos;
+      lb = startInterval->begin();
+      ub = startInterval->end();
+      goto skipSetup;
     }
 
     while (re <= readEndIt) {
-        // The distance from the beginning of the read to the
-        // start of the k-mer
-        pos = std::distance(readStartIt, rb);
+      // The distance from the beginning of the read to the
+      // start of the k-mer
+      pos = std::distance(readStartIt, rb);
 
-        //re = rb + k;
-        if (re > readEndIt) {
-          break;
-        }
-
-        // See if this k-mer would contain an N
-        // only check if we don't yet know that there are no remaining
-        // Ns
-        if (invalidPos != std::string::npos) {
-          invalidPos = read.find_first_of("nN", pos);
-        }
-
+      // See if this k-mer would contain an N
+      // only check if we don't yet know that there are no remaining
+      // Ns
+      if (invalidPos != std::string::npos) {
+        invalidPos = read.find_first_of("nN", pos);
         // If the first N is within k bases, then this k-mer is invalid
         if (invalidPos < pos + k) {
-          // Skip to the k-mer starting at the next position
-          // (i.e. right past the N)
-          rb = read.begin() + invalidPos + 1;
-          re = rb + k;
-          // Go to the next iteration of the while loop
-          continue;
+            // Skip to the k-mer starting at the next position
+            // (i.e. right past the N)
+            rb = read.begin() + invalidPos + 1;
+            re = rb + k;
+            // Go to the next iteration of the while loop
+            continue;
         }
+      }
 
-        if (re <= readEndIt) {
-        // Get the k-mer and query it in the hash
-        mer = rapmap::utils::my_mer(read.c_str() + pos);
-        if (mer.is_homopolymer()) {
-          rb += homoPolymerSkip;
-          re += homoPolymerSkip;
-          continue;
+      // Get the k-mer
+      mer = rapmap::utils::my_mer(read.c_str() + pos);
+      // If this is a homopolymer, then skip it
+      if (mer.is_homopolymer()) {
+        char nuc = std::toupper(*rb);
+        while (std::toupper(*re) == nuc) {
+          ++rb;
+          ++re;
+          // if we walk off the end, then we're done
+          if (re > readEndIt) {
+            return;
+          }
         }
-        complementMer = mer.get_reverse_complement();
-        merIt = khash.find(mer.get_bits(0, 2 * k));
+        // we found a different character
+        pos = std::distance(readStartIt, rb);
+        /*
+      rb += homoPolymerSkip;
+      re += homoPolymerSkip;
+      // If the default skip jumps us off the end of the read
+      // then try to check the last k-mer
+      if (re >= readEndIt and !lastSearch) {
+        rb = readEndIt - k;
+        re = rb + k;
+        // but give up if that's still a homopolymer
+        lastSearch = true;
+      }
+      continue;
+        */
+      }
+      // If it's not a homopolymer, then get the complement
+      // k-mer and query both in the hash.
+      complementMer = mer.get_reverse_complement();
+      merIt = khash.find(mer.get_bits(0, 2 * k));
 
-        // If we found the k-mer
-        if (merIt != hashEnd) {
-          if (strictCheck) {
-            ++strandHits;
-            kmerScores.emplace_back(mer, pos, ABSENT, ABSENT);
-            if (isRC) {
-                kmerScores.back().rcScore = PRESENT;
+      // If we found the k-mer
+      if (merIt != hashEnd) {
+        if (strictCheck_) {
+          ++strandHits;
+          // If we're on the reverse complement strand, then
+          // we have to adjust kmerPos to be with respect to the
+          // forward strand.
+          if (isRC) {
+            auto kp = pos;
+            pos = readLen - kp - k;
+            mer = mer.get_reverse_complement();
+          }
+          kmerScores.emplace_back(mer, pos, ABSENT, ABSENT);
+          if (isRC) {
+            kmerScores.back().rcScore = PRESENT;
+          } else {
+            kmerScores.back().fwdScore = PRESENT;
+          }
+
+          complementMerIt = khash.find(complementMer.get_bits(0, 2 * k));
+          if (complementMerIt != hashEnd) {
+            ++otherStrandHits;
+            if (isRC) { // if we are RC, the other strand is fwd
+              kmerScores.back().fwdScore = PRESENT;
             } else {
-                kmerScores.back().fwdScore = PRESENT;
-            }
-
-            complementMerIt = khash.find(complementMer.get_bits(0, 2 * k));
-            if (complementMerIt != hashEnd) {
-                ++otherStrandHits;
-                if (isRC) { // if we are RC, the other strand is fwd
-                    kmerScores.back().fwdScore = PRESENT;
-                } else {
-                    kmerScores.back().rcScore = PRESENT;
-                }
+              kmerScores.back().rcScore = PRESENT;
             }
           }
+        }
         lb = merIt->second.begin();
         ub = merIt->second.end();
-    skipSetup:
-          // lb must be 1 *less* then the current lb
-          // We can't move any further in the reverse complement direction
-          lb = std::max(static_cast<OffsetT>(0), lb - 1);
-          std::tie(lb, ub, matchedLen) =
-              saSearcher.extendSearchNaive(lb, ub, k, rb, re);
+      skipSetup:
+        // lb must be 1 *less* then the current lb
+        // We can't move any further in the reverse complement direction
+        lb = std::max(static_cast<OffsetT>(0), lb - 1);
+        std::tie(lb, ub, matchedLen) =
+            saSearcher.extendSearchNaive(lb, ub, k, rb, readEndIt);
 
-          OffsetT diff = ub - lb;
-          if (ub > lb and diff < maxInterval_) {
-            uint32_t queryStart = static_cast<uint32_t>(std::distance(readStartIt, rb));
-            saInts.emplace_back(lb, ub, matchedLen, queryStart, isRC);
+        OffsetT diff = ub - lb;
+        if (ub > lb and diff < maxInterval_) {
+          uint32_t queryStart =
+              static_cast<uint32_t>(std::distance(readStartIt, rb));
+          saInts.emplace_back(lb, ub, matchedLen, queryStart, isRC);
 
-            cov += matchedLen;
+          size_t matchOffset = std::distance(readStartIt, rb);
+          size_t correction = 0;
+          
+          // NOTE: prevMMPEnd points 1 position past the last *match* of the
+          // previous MMP (i.e. it points to the *first mismatch*).  This is 
+          // why we ignore the case where prevMMPEnd == matchOffset, and why 
+          // we don't have to add 1 to correction.
+          if (prevMMPEnd > matchOffset) {
+            correction = prevMMPEnd - matchOffset;
+          }
+          // Update the coverage and position of the last MMP match
+          cov += (matchedLen - correction);
+          prevMMPEnd = matchOffset + matchedLen;
 
-            // If we didn't end the match b/c we exhausted the query
-            // test the mismatching k-mer in the other strand
-            // TODO: check for 'N'?
-            if (strictCheck_ and rb + matchedLen < readEndIt) {
-              int32_t kmerPos =
-                  static_cast<int32_t>(
-                                       std::distance(readStartIt, 
-                                       rb + matchedLen - skipOverlap));
-              mer = rapmap::utils::my_mer(read.c_str() + kmerPos);
-              // If we're on the reverse complement strand, then
-              // we have to adjust kmerPos to be with respect to the 
-              // forward strand.
-              if (isRC) {
+          // If we didn't end the match b/c we exhausted the query
+          // test the mismatching k-mer in the other strand
+          if (strictCheck_ and rb + matchedLen < readEndIt) {
+            int32_t kmerPos = static_cast<int32_t>(
+                std::distance(readStartIt, rb + matchedLen - skipOverlapMMP));
+
+            // validNucs is true if mer contained no 'Ns'
+            bool validNucs = mer.from_chars(read.c_str() + kmerPos);
+            if (validNucs) {
+                // no hit on the current strand
+
+                // If we're on the reverse complement strand, then
+                // we have to adjust kmerPos to be with respect to the
+                // forward strand.
+                if (isRC) {
                   auto kp = kmerPos;
                   kmerPos = readLen - kp - k;
                   mer = mer.get_reverse_complement();
-              }
-              // TODO: 04/11/16
-              // Can we change this yet?
-              kmerScores.emplace_back(mer, kmerPos, UNTESTED, UNTESTED);
-              if (isRC) {
-                  kmerScores.back().rcScore = ABSENT;
-              } else {
-                  kmerScores.back().fwdScore = ABSENT;
-              }
-            }
-          }
-
-          if (lastSearch) { return; }
-
-          auto mismatchIt = rb + matchedLen;
-          if (mismatchIt < readEndIt) {
-            auto remainingDistance = std::distance(mismatchIt, readEndIt);
-            auto lce = disableNIP_
-                           ? matchedLen
-                           : saSearcher.lce(lb, ub - 1,
-                                            matchedLen, remainingDistance);
-
-
-            // Where we would jump if we just used the MMP
-            auto skipMatch = mismatchIt - skipOverlap;
-            // Where we would jump if we used the LCE
-            auto skipLCE = rb + lce - skipOverlap;
-
-            auto maxSkip = std::max(skipMatch, skipLCE);
-            rb = maxSkip;
-     
-            // If NIP skipping is *enabled*, and we got to the current position
-            // by doing an LCE query, then we allow ourselves to *double check*
-            // by querying the last k-mer in the read.
-            // Otherwise, we just take the skip we're given.
-            if (!disableNIP_ and (lce > matchedLen)) {
-                if (readLen > k) {
-                    rb = std::min(readEndIt - k, rb);
                 }
-            } 
+                kmerScores.emplace_back(mer, kmerPos, ABSENT, ABSENT);
+                
+                // Test the complementary strand
+                complementMer = mer.get_reverse_complement();
+                complementMerIt = khash.find(complementMer.get_bits(0, 2 * k));
+                if (complementMerIt != hashEnd) {
+                    ++otherStrandHits;
+                    if (isRC) { // if we are RC, the other strand is fwd
+                        kmerScores.back().fwdScore = PRESENT;
+                    } else {
+                        kmerScores.back().rcScore = PRESENT;
+                    }
+                }
+            } // The k-mer was valid (had no Ns)
+          } // we're performing a strict check
+        } // This hit was worth recording --- occurred fewer then maxInterval_ times
 
-
-            re = rb + k;
-            if (re == readEndIt) { lastSearch = true; }
-          } else {
-              return;
-          }
-        } else {
-          rb += sampFactor;
-          re = rb + k;
+        // If we've previously declared that the search that just occurred was our last, then we're done!
+        if (lastSearch) {
+          return;
         }
-    }
+
+        // Otherwise, figure out how we should continue the search.
+        auto mismatchIt = rb + matchedLen;
+        // If we reached the end of the read, then we're done.
+        if (mismatchIt >= readEndIt) {
+            return;
+        }
+
+        auto remainingDistance = std::distance(mismatchIt, readEndIt);
+        auto lce = disableNIP_ ? matchedLen
+                               : saSearcher.lce(lb, ub - 1, matchedLen,
+                                                remainingDistance);
+
+        // Where we would jump if we just used the MMP
+        auto skipMatch = mismatchIt - skipOverlapMMP;
+        //if (skipMatch + k )
+        // Where we would jump if we used the LCE
+        auto skipLCE = rb + lce - skipOverlapNIP;
+        // Pick the maximum of the two
+        auto maxSkip = std::max(skipMatch, skipLCE);
+        // And that's where our new search will start
+        rb = maxSkip;
+
+        // If NIP skipping is *enabled*, and we got to the current position
+        // by doing an LCE query, then we allow ourselves to *double check*
+        // by querying the last k-mer in the read.
+        // Otherwise, we just take the skip we're given.
+        if (!disableNIP_ and (lce > matchedLen)) {
+          if (readLen > k) {
+            rb = std::min(readEndIt - k, rb);
+          }
+        }
+
+        re = rb + k;
+
+        // If the search ends at the end of the read, then
+        // set the flag that we need not try after this.
+        if (re == readEndIt) {
+          lastSearch = true;
+        }
+
+      } else { // If we couldn't match this k-mer, move on to the next.
+        rb += sampFactor;
+        re = rb + k;
       }
-}   
+    }
+  }
 
   RapMapIndexT* rmi_;
-  bool disableNIP_{false};
-  double covReq_{0.0};
+  bool disableNIP_;
+  double covReq_;
   OffsetT maxInterval_;
   bool strictCheck_;
-    std::string rcBuffer_;
-  std::mutex iomutex_;
+  std::string rcBuffer_;
 };
 
 #endif // SA_COLLECTOR_HPP

--- a/include/ScopedTimer.hpp
+++ b/include/ScopedTimer.hpp
@@ -29,15 +29,18 @@ struct ScopedTimer
 {
     std::chrono::high_resolution_clock::time_point t0;
 
-    ScopedTimer()
-        : t0(std::chrono::high_resolution_clock::now())
+    ScopedTimer(bool print=true)
+        : t0(std::chrono::high_resolution_clock::now()), print_(print)
     { }
     ~ScopedTimer(void)
     {
         auto  t1 = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> elapsedSec =  t1 - t0;
-        std::cerr << "Elapsed time: " << elapsedSec.count() << "s\n";
+        if (print_) { std::cerr << "Elapsed time: " << elapsedSec.count() << "s\n"; }
     }
+
+private: 
+bool print_;
 };
 
 #endif //__SCOPED_TIMER_HPP__

--- a/src/HitManager.cpp
+++ b/src/HitManager.cpp
@@ -32,7 +32,7 @@ namespace rapmap {
                 uint32_t maxDist,
                 std::vector<QuasiAlignment>& hits,
                 MateStatus mateStatus){
-            bool foundHit{false};
+            //bool foundHit{false};
             // One processed hit per transcript
             for (auto& ph : processedHits) {
                 auto tid = ph.tid;
@@ -62,9 +62,9 @@ namespace rapmap {
                         uint32_t maxDist,
                         std::vector<QuasiAlignment>& hits,
                         MateStatus mateStatus){
-                bool foundHit{false};
+                //bool foundHit{false};
                 // One processed hit per transcript
-	            auto startOffset = hits.size();
+	            //auto startOffset = hits.size();
                 for (auto& ph : processedHits) {
                         // If this is an *active* position list
                         if (ph.second.active) {
@@ -99,7 +99,7 @@ namespace rapmap {
                         uint32_t maxDist,
                         std::vector<QuasiAlignment>& hits,
                         MateStatus mateStatus){
-                bool foundHit{false};
+                //bool foundHit{false};
 
                 // One processed hit per transcript
                 for (auto& ph : processedHits) {
@@ -149,7 +149,7 @@ namespace rapmap {
             // Iterator into, length of and end of the positon list for h2
             auto rightPosIt = posList.begin() + h2.kinfo->offset;
             auto rightPosLen = h2.kinfo->count;
-            auto rightPosEnd = rightPosIt + rightPosLen;
+            // auto rightPosEnd = rightPosIt + rightPosLen;
             // Iterator into, length of and end of the transcript list for h2
             auto rightTxpIt = eqClassLabels.begin() + eqClassRight.txpListStart;
             auto rightTxpListLen = eqClassRight.txpListLen;
@@ -374,7 +374,6 @@ namespace rapmap {
             // Convenient bindings for variables we'll use
             auto& SA = rmi.SA;
             //auto& txpIDs = rmi.positionIDs;
-            auto& rankDict = rmi.rankDict;
             auto& txpStarts = rmi.txpOffsets;
 
             // Walk through every hit in the new interval 'h'
@@ -439,7 +438,7 @@ namespace rapmap {
                 // Iterator into, length of and end of the positon list
                 auto posIt = posList.begin() + minHit->kinfo->offset;
                 auto posLen = minHit->kinfo->count;
-                auto posEnd = posIt + posLen;
+                // auto posEnd = posIt + posLen;
                 // Iterator into, length of and end of the transcript list
                 auto txpIt = eqClassLabels.begin() + eqClass.txpListStart;
                 auto txpListLen = eqClass.txpListLen;
@@ -623,7 +622,6 @@ namespace rapmap {
             auto& SA = rmi.SA;
             auto& txpStarts = rmi.txpOffsets;
             //auto& txpIDs = rmi.positionIDs;
-	    auto& rankDict = rmi.rankDict;
 
             // Start with the smallest interval
             // i.e. interval with the fewest hits.

--- a/src/HitManager.cpp
+++ b/src/HitManager.cpp
@@ -20,6 +20,7 @@
 //
 
 #include "HitManager.hpp"
+#include "BooMap.hpp"
 #include "FrugalBooMap.hpp"
 #include <type_traits>
 
@@ -674,8 +675,8 @@ namespace rapmap {
 									     rapmap::utils::KmerKeyHasher>>;
       using SAIndex64BitDense = RapMapSAIndex<int64_t, RegHashT<uint64_t, rapmap::utils::SAInterval<int64_t>,
 									     rapmap::utils::KmerKeyHasher>>;
-      using SAIndex32BitPerfect = RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-      using SAIndex64BitPerfect = RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+      using SAIndex32BitPerfect = RapMapSAIndex<int32_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+      using SAIndex64BitPerfect = RapMapSAIndex<int64_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
 
         template
         void intersectSAIntervalWithOutput<SAIndex32BitDense>(SAIntervalHit<int32_t>& h,

--- a/src/HitManager.cpp
+++ b/src/HitManager.cpp
@@ -20,7 +20,7 @@
 //
 
 #include "HitManager.hpp"
-#include "BooMap.hpp"
+#include "FrugalBooMap.hpp"
 #include <type_traits>
 
 namespace rapmap {
@@ -674,8 +674,8 @@ namespace rapmap {
 									     rapmap::utils::KmerKeyHasher>>;
       using SAIndex64BitDense = RapMapSAIndex<int64_t, RegHashT<uint64_t, rapmap::utils::SAInterval<int64_t>,
 									     rapmap::utils::KmerKeyHasher>>;
-      using SAIndex32BitPerfect = RapMapSAIndex<int32_t, BooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-      using SAIndex64BitPerfect = RapMapSAIndex<int64_t, BooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+      using SAIndex32BitPerfect = RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+      using SAIndex64BitPerfect = RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
 
         template
         void intersectSAIntervalWithOutput<SAIndex32BitDense>(SAIntervalHit<int32_t>& h,

--- a/src/RapMapSAIndex.cpp
+++ b/src/RapMapSAIndex.cpp
@@ -19,7 +19,7 @@
 // along with RapMap.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-//#include "BooMap.hpp"
+#include "BooMap.hpp"
 #include "FrugalBooMap.hpp"
 #include "RapMapSAIndex.hpp"
 #include "IndexHeader.hpp"
@@ -62,7 +62,7 @@ bool loadHashFromIndex(const std::string& indexDir,
 
 template <typename IndexT>
 bool loadHashFromIndex(const std::string& indexDir,
-		       FrugalBooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> & h) {
+		       PerfectHashT<uint64_t, rapmap::utils::SAInterval<IndexT>> & h) {
     std::string hashBase = indexDir + "hash_info";
     h.load(hashBase);
     return true;
@@ -173,5 +173,5 @@ template class RapMapSAIndex<int32_t,  RegHashT<uint64_t,
 template class RapMapSAIndex<int64_t,  RegHashT<uint64_t,
                       rapmap::utils::SAInterval<int64_t>,
                       rapmap::utils::KmerKeyHasher>>;
-template class RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-template class RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+template class RapMapSAIndex<int32_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+template class RapMapSAIndex<int64_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int64_t>>>;

--- a/src/RapMapSAIndex.cpp
+++ b/src/RapMapSAIndex.cpp
@@ -47,6 +47,21 @@ void set_empty_key(spp::sparse_hash_map<uint64_t,
 }
 */
 
+    // Set the SA and text pointer if this is a perfect hash
+template <typename IndexT>
+void setPerfectHashPointers(RegHashT<uint64_t,
+                            rapmap::utils::SAInterval<IndexT>,
+                            rapmap::utils::KmerKeyHasher>& khash, std::vector<IndexT>& SA, std::string& seq) {
+    // do nothing
+}
+
+template <typename IndexT>
+void setPerfectHashPointers(PerfectHashT<uint64_t,
+                            rapmap::utils::SAInterval<IndexT>>& khash, std::vector<IndexT>& SA, std::string& seq) {
+    khash.setSAPtr(&SA);
+    khash.setTextPtr(seq.c_str(), seq.length());
+}
+
 // These are **free** functions that are used for loading the
 // appropriate type of hash.
 template <typename IndexT>
@@ -162,7 +177,8 @@ bool RapMapSAIndex<IndexT, HashT>::load(const std::string& indDir) {
         logger->error("Failed to load hash!");
         std::exit(1);
     }
-
+    // Set the SA and text pointer if this is a perfect hash
+    setPerfectHashPointers(khash, SA, seq); 
     logger->info("Done loading index");
     return true;
 }

--- a/src/RapMapSAIndex.cpp
+++ b/src/RapMapSAIndex.cpp
@@ -19,7 +19,8 @@
 // along with RapMap.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "BooMap.hpp"
+//#include "BooMap.hpp"
+#include "FrugalBooMap.hpp"
 #include "RapMapSAIndex.hpp"
 #include "IndexHeader.hpp"
 #include <cereal/types/unordered_map.hpp>
@@ -61,7 +62,7 @@ bool loadHashFromIndex(const std::string& indexDir,
 
 template <typename IndexT>
 bool loadHashFromIndex(const std::string& indexDir,
-		       BooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> & h) {
+		       FrugalBooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> & h) {
     std::string hashBase = indexDir + "hash_info";
     h.load(hashBase);
     return true;
@@ -172,5 +173,5 @@ template class RapMapSAIndex<int32_t,  RegHashT<uint64_t,
 template class RapMapSAIndex<int64_t,  RegHashT<uint64_t,
                       rapmap::utils::SAInterval<int64_t>,
                       rapmap::utils::KmerKeyHasher>>;
-template class RapMapSAIndex<int32_t, BooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-template class RapMapSAIndex<int64_t, BooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+template class RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+template class RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;

--- a/src/RapMapSAIndex.cpp
+++ b/src/RapMapSAIndex.cpp
@@ -91,6 +91,7 @@ bool RapMapSAIndex<IndexT, HashT>::load(const std::string& indDir) {
     }
     indexStream.close();
     uint32_t idxK = h.kmerLen();
+    rapmap::utils::my_mer::k(idxK);
 
     // This part takes the longest, so do it in it's own asynchronous task
     std::future<bool> loadingHash = std::async(std::launch::async, [this, logger, indDir]() -> bool {
@@ -160,7 +161,6 @@ bool RapMapSAIndex<IndexT, HashT>::load(const std::string& indDir) {
         logger->error("Failed to load hash!");
         std::exit(1);
     }
-    rapmap::utils::my_mer::k(idxK);
 
     logger->info("Done loading index");
     return true;

--- a/src/RapMapSAIndexer.cpp
+++ b/src/RapMapSAIndexer.cpp
@@ -42,6 +42,7 @@
 #include <cereal/types/vector.hpp>
 
 #include "BooMap.hpp"
+//#include "FrugalBooMap.hpp"
 #include "xxhash.h"
 
 #include "spdlog/spdlog.h"
@@ -125,6 +126,9 @@ bool buildPerfectHash(const std::string& outputDir, std::string& concatText,
                       size_t tlen, uint32_t k, std::vector<IndexT>& SA,
                       uint32_t numHashThreads) {
   BooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> intervals;
+  //FrugalBooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> intervals;
+  //intervals.setSAPtr(&SA);
+  //intervals.setTextPtr(concatText.data(), concatText.length());
 
   // The start and stop of the current interval
   IndexT start = 0, stop = 0;

--- a/src/RapMapSAIndexer.cpp
+++ b/src/RapMapSAIndexer.cpp
@@ -41,7 +41,7 @@
 #include <cereal/types/utility.hpp>
 #include <cereal/types/vector.hpp>
 
-//#include "BooMap.hpp"
+#include "BooMap.hpp"
 #include "FrugalBooMap.hpp"
 #include "xxhash.h"
 
@@ -126,7 +126,7 @@ bool buildPerfectHash(const std::string& outputDir, std::string& concatText,
                       size_t tlen, uint32_t k, std::vector<IndexT>& SA,
                       uint32_t numHashThreads) {
   //BooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> intervals;
-  FrugalBooMap<uint64_t, rapmap::utils::SAInterval<IndexT>> intervals;
+  PerfectHashT<uint64_t, rapmap::utils::SAInterval<IndexT>> intervals;
   intervals.setSAPtr(&SA);
   intervals.setTextPtr(concatText.data(), concatText.length());
 

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -112,10 +112,10 @@ using FixedWriter = rapmap::utils::FixedWriter;
 
 
 
-template <typename RapMapIndexT, typename CollectorT, typename MutexT>
+template <typename RapMapIndexT, typename MutexT>
 void processReadsSingleSA(single_parser * parser,
                           RapMapIndexT& rmi,
-                          CollectorT& hitCollector,
+                          //CollectorT& hitCollector,
                           MutexT* iomutex,
                           std::shared_ptr<spdlog::logger> outQueue,
                           HitCounters& hctr,
@@ -125,6 +125,8 @@ void processReadsSingleSA(single_parser * parser,
                           bool consistentHits) {
 
     using OffsetT = typename RapMapIndexT::IndexType;
+
+    SACollector<RapMapIndexT> hitCollector(&rmi);
     auto& txpNames = rmi.txpNames;
     auto& txpLens = rmi.txpLens;
     uint32_t n{0};
@@ -220,10 +222,10 @@ void processReadsSingleSA(single_parser * parser,
 /**
  *  Map reads from a collection of paired-end files.
  */
-template <typename RapMapIndexT, typename CollectorT, typename MutexT>
+template <typename RapMapIndexT, typename MutexT>
 void processReadsPairSA(paired_parser* parser,
                         RapMapIndexT& rmi,
-                        CollectorT& hitCollector,
+                        //CollectorT& hitCollector,
                         MutexT* iomutex,
                         std::shared_ptr<spdlog::logger> outQueue,
                         HitCounters& hctr,
@@ -235,6 +237,7 @@ void processReadsPairSA(paired_parser* parser,
 
     using OffsetT = typename RapMapIndexT::IndexType;
 
+    SACollector<RapMapIndexT> hitCollector(&rmi);
     auto& txpNames = rmi.txpNames;
     auto& txpLens = rmi.txpLens;
     uint32_t n{0};
@@ -366,10 +369,10 @@ bool spawnProcessReadsThreads(
             //saCollector.setCoverageRequirement(0.5);
 
             for (size_t i = 0; i < nthread; ++i) {
-                threads.emplace_back(processReadsPairSA<RapMapIndexT, SACollector<RapMapIndexT>, MutexT>,
+                threads.emplace_back(processReadsPairSA<RapMapIndexT, MutexT>,
                                      parser,
                                      std::ref(rmi),
-                                     std::ref(saCollector),
+                                     //std::ref(saCollector),
                                      &iomutex,
                                      outQueue,
                                      std::ref(hctr),
@@ -398,12 +401,11 @@ bool spawnProcessReadsThreads(
                               bool consistentHits) {
 
             std::vector<std::thread> threads;
-            SACollector<RapMapIndexT> saCollector(&rmi);
             for (size_t i = 0; i < nthread; ++i) {
-                threads.emplace_back(processReadsSingleSA<RapMapIndexT, SACollector<RapMapIndexT>, MutexT>,
+                threads.emplace_back(processReadsSingleSA<RapMapIndexT, MutexT>,
                                      parser,
                                      std::ref(rmi),
-                                     std::ref(saCollector),
+                                     //std::ref(saCollector),
                                      &iomutex,
                                      outQueue,
                                      std::ref(hctr),

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -66,8 +66,9 @@
 #include "kseq.h"
 }
 */
+
 #include "stringpiece.h"
-//#include "BooMap.hpp"
+#include "BooMap.hpp"
 #include "FrugalBooMap.hpp"
 #include "PairSequenceParser.hpp"
 #include "PairAlignmentFormatter.hpp"
@@ -639,7 +640,7 @@ int rapMapSAMap(int argc, char* argv[]) {
       //BigSAIdxPtr.reset(new RapMapSAIndex<int64_t>);
       //BigSAIdxPtr->load(indexPrefix, h.kmerLen());
       if (h.perfectHash()) {
-          RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>> rmi;
+          RapMapSAIndex<int64_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int64_t>>> rmi;
           rmi.load(indexPrefix);
           rmi.khash.setSAPtr(&rmi.SA);
           rmi.khash.setTextPtr(rmi.seq.c_str(), rmi.seq.length());
@@ -660,7 +661,7 @@ int rapMapSAMap(int argc, char* argv[]) {
       //SAIdxPtr.reset(new RapMapSAIndex<int32_t>);
       //SAIdxPtr->load(indexPrefix, h.kmerLen());
         if (h.perfectHash()) {
-            RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>> rmi;
+            RapMapSAIndex<int32_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int32_t>>> rmi;
             rmi.load(indexPrefix);
             rmi.khash.setSAPtr(&rmi.SA);
             rmi.khash.setTextPtr(rmi.seq.c_str(), rmi.seq.length());

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -548,7 +548,10 @@ int rapMapSAMap(int argc, char* argv[]) {
   cmd.add(fuzzy);
   cmd.add(consistent);
 
-  auto consoleSink = std::make_shared<spdlog::sinks::stderr_sink_mt>();
+  
+  auto rawConsoleSink = std::make_shared<spdlog::sinks::stderr_sink_mt>();
+  auto consoleSink =
+      std::make_shared<spdlog::sinks::ansicolor_sink>(rawConsoleSink);
   auto consoleLog = spdlog::create("stderrLog", {consoleSink});
 
   try {

--- a/src/RapMapSAMapper.cpp
+++ b/src/RapMapSAMapper.cpp
@@ -472,7 +472,7 @@ bool mapReads(RapMapIndexT& rmi,
 	size_t queueSize{268435456};
 	spdlog::set_async_mode(queueSize);
 	auto outputSink = std::make_shared<spdlog::sinks::ostream_sink_mt>(outStream);
-	std::shared_ptr<spdlog::logger> outLog = std::make_shared<spdlog::logger>("outLog", outputSink);
+	std::shared_ptr<spdlog::logger> outLog = std::make_shared<spdlog::logger>("rapmap::outLog", outputSink);
 	outLog->set_pattern("%v");
 
 	uint32_t nthread = numThreads.getValue();

--- a/src/RapMapUtils.cpp
+++ b/src/RapMapUtils.cpp
@@ -30,7 +30,8 @@
 #include "SingleAlignmentFormatter.hpp"
 //#include "jellyfish/whole_sequence_parser.hpp"
 #include "FastxParser.hpp"
-#include "BooMap.hpp"
+//#include "BooMap.hpp"
+#include "FrugalBooMap.hpp"
 
 namespace rapmap {
     namespace utils {
@@ -526,8 +527,8 @@ using SAIndex32BitDense = RapMapSAIndex<int32_t, RegHashT<uint64_t, rapmap::util
 								       rapmap::utils::KmerKeyHasher>>;
 using SAIndex64BitDense = RapMapSAIndex<int64_t, RegHashT<uint64_t, rapmap::utils::SAInterval<int64_t>,
 								       rapmap::utils::KmerKeyHasher>>;
-using SAIndex32BitPerfect = RapMapSAIndex<int32_t, BooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-using SAIndex64BitPerfect = RapMapSAIndex<int64_t, BooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+using SAIndex32BitPerfect = RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+using SAIndex64BitPerfect = RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
 
 // Explicit instantiations
 // pair parser, 32-bit, dense hash

--- a/src/RapMapUtils.cpp
+++ b/src/RapMapUtils.cpp
@@ -291,7 +291,7 @@ namespace rapmap {
                         rapmap::utils::getSamFlags(qa, true, flags1, flags2);
                         if (alnCtr != 0) {
                             flags1 |= 0x100; flags2 |= 0x100;
-                        }
+                        } 
 
                         auto txpLen = txpLens[qa.tid];
                         rapmap::utils::adjustOverhang(qa, txpLens[qa.tid], cigarStr1, cigarStr2);
@@ -362,6 +362,7 @@ namespace rapmap {
                         if (alnCtr != 0) {
                             flags1 |= 0x100; flags2 |= 0x100;
                         }
+
 			/*
 			else {
                             // If this is the first alignment for this read
@@ -462,7 +463,7 @@ namespace rapmap {
                             << transcriptName << '\t' // RNAME (same as mate)
                             << qa.pos + 1 << '\t' // POS (same as mate)
                             << 0 << '\t' // MAPQ
-                            << unalignedSeq->length() << 'S' << '\t' // CIGAR
+                            << "*\t" // CIGAR
                             << '=' << '\t' // RNEXT
                             << qa.pos + 1 << '\t' // PNEXT (only 1 read in template)
                             << 0 << '\t' // TLEN (spec says 0, not read len)

--- a/src/RapMapUtils.cpp
+++ b/src/RapMapUtils.cpp
@@ -30,7 +30,7 @@
 #include "SingleAlignmentFormatter.hpp"
 //#include "jellyfish/whole_sequence_parser.hpp"
 #include "FastxParser.hpp"
-//#include "BooMap.hpp"
+#include "BooMap.hpp"
 #include "FrugalBooMap.hpp"
 
 namespace rapmap {
@@ -527,8 +527,8 @@ using SAIndex32BitDense = RapMapSAIndex<int32_t, RegHashT<uint64_t, rapmap::util
 								       rapmap::utils::KmerKeyHasher>>;
 using SAIndex64BitDense = RapMapSAIndex<int64_t, RegHashT<uint64_t, rapmap::utils::SAInterval<int64_t>,
 								       rapmap::utils::KmerKeyHasher>>;
-using SAIndex32BitPerfect = RapMapSAIndex<int32_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
-using SAIndex64BitPerfect = RapMapSAIndex<int64_t, FrugalBooMap<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
+using SAIndex32BitPerfect = RapMapSAIndex<int32_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int32_t>>>;
+using SAIndex64BitPerfect = RapMapSAIndex<int64_t, PerfectHashT<uint64_t, rapmap::utils::SAInterval<int64_t>>>;
 
 // Explicit instantiations
 // pair parser, 32-bit, dense hash

--- a/src/RapMapUtils.cpp
+++ b/src/RapMapUtils.cpp
@@ -125,6 +125,12 @@ namespace rapmap {
             //std::swap(qual, qualWork);
         }
 
+        std::string reverseComplement(std::string& seq) {
+            std::string work;
+            reverseRead(seq, work);
+            return work;
+        }
+
         template <typename ReadT, typename IndexT>
         uint32_t writeAlignmentsToStream(
                 ReadT& r,


### PR DESCRIPTION
This PR constitutes a substantial refactoring of the SA collector code.  It simplifies the main function `operator()` significantly, and also fixes some bugs.  The refactor also replaces the previous perfect-hash-function based index with a slower but much smaller *frugal* perfect-hash-function based index.  It also replaces the default hash in the quasiindex (previously google's dense hash) with sparsepp, which has almost identical performance but uses much less space (and  grows much more linearly with the number of keys).